### PR TITLE
Authorized patch operation with capital letter as required by azure AD

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -13,12 +13,14 @@ export interface ScimResource {
 
 // Object to represent PATCH inputs (RFC-7644)
 export interface ScimPatchRemoveOperation {
-  readonly op: 'remove';
+  // We accept value with capital letter to be compliant with AzureAD
+  readonly op: 'remove' | 'Remove';
   readonly path: string;
 }
 
 export interface ScimPatchAddReplaceOperation {
-  readonly op: 'add' | 'replace';
+  // We accept value with capital letter to be compliant with AzureAD
+  readonly op: 'add' | 'Add' | 'replace' | 'Replace';
   readonly path?: string;
   readonly value?: any;
 }

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -202,6 +202,14 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.emails[0].primary).to.eq(true);
             return done();
         });
+
+        it('REPLACE: with capital first letter for operation', done => {
+            const expected = false;
+            const patch: ScimPatchAddReplaceOperation = {op: 'Replace', value: {active: expected}};
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch.active).to.be.eq(expected);
+            return done();
+        });
     });
 
     describe('add', () => {
@@ -386,6 +394,14 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.name.nestedArray).to.be.eq(scimUser.name.nestedArray);
             return done();
         });
+
+        it('ADD: with capital first letter for operation', done => {
+            const expected = 'newValue';
+            const patch: ScimPatchAddReplaceOperation = {op: 'Add', value: {newProperty: expected}};
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch.newProperty).to.be.eq(expected);
+            return done();
+        });
     });
     describe('remove', () => {
         it('REMOVE: with no path', done => {
@@ -445,6 +461,13 @@ describe('SCIM PATCH', () => {
             const patch1: ScimPatchRemoveOperation = {op: 'remove', path: 'name.nestedArray[primary eq true]'};
             const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch1]);
             expect(afterPatch.name.nestedArray).not.to.exist;
+            return done();
+        });
+
+        it('REMOVE: with capital first letter for operation', done => {
+            const patch: ScimPatchRemoveOperation = {op: 'Remove', path: 'active'};
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch.active).not.to.exist;
             return done();
         });
     });


### PR DESCRIPTION
Azure AD has a specific pattern when specifying patch operation names.

As you can see here https://docs.microsoft.com/en-us/azure/active-directory/app-provisioning/use-scim-to-provision-users-and-groups#step-2-understand-the-azure-ad-scim-implementation
> Don't require a case-sensitive match on structural elements in SCIM, in particular PATCH op operation values, as defined in https://tools.ietf.org/html/rfc7644#section-3.5.2. Azure AD emits the values of 'op' as Add, Replace, and Remove.

This PR allows the use of a capital letter for operations names.
An issue is open https://github.com/thomaspoignant/scim-patch/issues/5 to be case insensitive for patch operation names. 