### PR TITLE
Update scim2-parse-filter version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1919,9 +1919,9 @@
       "dev": true
     },
     "scim2-parse-filter": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/scim2-parse-filter/-/scim2-parse-filter-0.1.0.tgz",
-      "integrity": "sha512-XEQc2xgIsMFSz0lnL0Dpi0gcuLv0iYsbmpB26BxxktsCcPJvRhQ1A1syUlhd5jp2fsvQlG9+yFk9+m1tHBvujA=="
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/scim2-parse-filter/-/scim2-parse-filter-0.1.1.tgz",
+      "integrity": "sha512-RiH1BmWiK/7kYFMd6ZN3Fx1aolHXNk/4kcHRyhrcF9lFT2AQeyuvqs2th8p5d94p43VV9k3OTyvP96RxFkY4rA=="
     },
     "semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
-    "scim2-parse-filter": "^0.1.0"
+    "scim2-parse-filter": "^0.1.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Move to version `0.1.1` of `scim2-parse-filter`.