### PR TITLE
Handle Azure AD schema paths

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -122,7 +122,7 @@ function applyAddOperation(scimResource: ScimResource, patch: ScimPatchAddReplac
         return addOrReplaceAttribute(scimResource, patch);
 
     // We navigate till the second to last of the path.
-    const paths = patch.path.split('.');
+    const paths = patch.path.split(/(?!\d)\.(?!\d)/g);
     resource = navigate(resource, paths);
     const lastSubPath = paths[paths.length - 1];
 
@@ -151,7 +151,7 @@ function applyRemoveOperation(scimResource: ScimResource, patch: ScimPatchRemove
     validatePatchOperation(patch);
 
     // Path is supposed to be set, there are a validation in the validateOperation function.
-    const paths = patch.path.split('.');
+    const paths = patch.path.split(/(?!\d)\.(?!\d)/g);
     resource = navigate(resource, paths);
 
     // Dealing with the last element of the path.
@@ -185,7 +185,7 @@ function applyReplaceOperation(scimResource: ScimResource, patch: ScimPatchAddRe
         return addOrReplaceAttribute(scimResource, patch);
 
     // We navigate till the second to last of the path.
-    const paths = patch.path.split('.');
+    const paths = patch.path.split(/(?!\d)\.(?!\d)/g);
     resource = navigate(resource, paths);
     const lastSubPath = paths[paths.length - 1];
 

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -46,6 +46,8 @@ export {
 const IS_ARRAY_SEARCH = /(\[|\])/;
 // Regex to extract key and search request (ex: emails[primary eq true).
 const ARRAY_SEARCH: RegExp = /^(.+)\[(.+)\]$/;
+// Split path on all periods except e.g. "2.0"
+const SPLIT_PERIOD = /(?!\d)\.(?!\d)/g;
 // Valid patch operation, value needs to be in lowercase here.
 const AUTHORIZED_OPERATION = ['remove', 'add', 'replace'];
 
@@ -122,7 +124,7 @@ function applyAddOperation(scimResource: ScimResource, patch: ScimPatchAddReplac
         return addOrReplaceAttribute(scimResource, patch);
 
     // We navigate till the second to last of the path.
-    const paths = patch.path.split(/(?!\d)\.(?!\d)/g);
+    const paths = patch.path.split(SPLIT_PERIOD);
     resource = navigate(resource, paths);
     const lastSubPath = paths[paths.length - 1];
 
@@ -151,7 +153,7 @@ function applyRemoveOperation(scimResource: ScimResource, patch: ScimPatchRemove
     validatePatchOperation(patch);
 
     // Path is supposed to be set, there are a validation in the validateOperation function.
-    const paths = patch.path.split(/(?!\d)\.(?!\d)/g);
+    const paths = patch.path.split(SPLIT_PERIOD);
     resource = navigate(resource, paths);
 
     // Dealing with the last element of the path.
@@ -185,7 +187,7 @@ function applyReplaceOperation(scimResource: ScimResource, patch: ScimPatchAddRe
         return addOrReplaceAttribute(scimResource, patch);
 
     // We navigate till the second to last of the path.
-    const paths = patch.path.split(/(?!\d)\.(?!\d)/g);
+    const paths = patch.path.split(SPLIT_PERIOD);
     resource = navigate(resource, paths);
     const lastSubPath = paths[paths.length - 1];
 

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -35,7 +35,8 @@ describe('SCIM PATCH', () => {
         "created": "2019-11-20T09:25:30.208Z",
         "lastModified": "2019-11-20T09:25:30.208Z",
         "location": "**REQUIRED**/Users/tea_4"
-      }
+      },
+      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department": "value"
     }`);
         return done();
     });
@@ -210,6 +211,19 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.active).to.be.eq(expected);
             return done();
         });
+
+        it('REPLACE: with version number in path', done => {
+            const expected = 'newValue';
+            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
+            const patch: ScimPatchAddReplaceOperation = {
+                op: 'replace',
+                value: expected,
+                path: path
+            };
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch[path]).to.be.eq(expected);
+            return done();
+        })
     });
 
     describe('add', () => {
@@ -402,6 +416,18 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.newProperty).to.be.eq(expected);
             return done();
         });
+
+        it('ADD: with version number in path', done => {
+            const expected = 'newValue';
+            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
+            delete scimUser[path];
+            const patch: ScimPatchAddReplaceOperation = {
+                op: 'add', value: 'newValue', path: path
+            };
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch[path]).to.be.eq(expected);
+            return done();
+        })
     });
     describe('remove', () => {
         it('REMOVE: with no path', done => {
@@ -470,6 +496,14 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.active).not.to.exist;
             return done();
         });
+
+        it('REMOVE: with version number in path', done => {
+            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
+            const patch: ScimPatchRemoveOperation = {op: 'remove', path: path};
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch[path]).not.to.exist;
+            return done();
+        })
     });
     describe('invalid requests', () => {
         it('INVALID: wrong operation name', done => {

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -39,4 +39,5 @@ export interface ScimUser extends ScimResource {
     meta: ScimMeta & { resourceType: 'User' };
     newProperty?: string;
     newProperty3?: string;
+    'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department'?: string;
 }


### PR DESCRIPTION
Hi,

When using provisioning with Azure AD we get paths which contain version numbers, e.g.
```json
{
    "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
    "Operations": [
        {
            "op": "Add",
            "path": "title",
            "value": "CTO"
        },
        {
            "op": "Add",
            "path": "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department",
            "value": "Development"
        }
    ]
}
```

With this pull request, those paths are handled correctly.