### PR TITLE
Support Azure AD schemas keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scim-patch",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "SCIM Patch operation (rfc7644).",
   "main": "lib/src/scimPatch.js",
   "types": "lib/src/scimPatch.d.ts",

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -116,7 +116,7 @@ function validatePatchOperation(operation: ScimPatchOperation): void {
 }
 
 function applyAddOperation(scimResource: ScimResource, patch: ScimPatchAddReplaceOperation): ScimResource {
-    // // We manipulate the object directly without knowing his property, that's why we use any.
+    // We manipulate the object directly without knowing his property, that's why we use any.
     let resource: Record<string, any> = scimResource;
     validatePatchOperation(patch);
 

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -46,6 +46,8 @@ export {
 const IS_ARRAY_SEARCH = /(\[|\])/;
 // Regex to extract key and search request (ex: emails[primary eq true).
 const ARRAY_SEARCH: RegExp = /^(.+)\[(.+)\]$/;
+// Regex to extract the path as an array.
+const PATH_SPLITTER: RegExp = /(?!\d)\.(?!\d)/g;
 // Valid patch operation, value needs to be in lowercase here.
 const AUTHORIZED_OPERATION = ['remove', 'add', 'replace'];
 
@@ -122,7 +124,7 @@ function applyAddOperation(scimResource: ScimResource, patch: ScimPatchAddReplac
         return addOrReplaceAttribute(scimResource, patch);
 
     // We navigate till the second to last of the path.
-    const paths = patch.path.split('.');
+    const paths = patch.path.split(PATH_SPLITTER);
     resource = navigate(resource, paths);
     const lastSubPath = paths[paths.length - 1];
 
@@ -151,7 +153,7 @@ function applyRemoveOperation(scimResource: ScimResource, patch: ScimPatchRemove
     validatePatchOperation(patch);
 
     // Path is supposed to be set, there are a validation in the validateOperation function.
-    const paths = patch.path.split('.');
+    const paths = patch.path.split(PATH_SPLITTER);
     resource = navigate(resource, paths);
 
     // Dealing with the last element of the path.
@@ -185,7 +187,7 @@ function applyReplaceOperation(scimResource: ScimResource, patch: ScimPatchAddRe
         return addOrReplaceAttribute(scimResource, patch);
 
     // We navigate till the second to last of the path.
-    const paths = patch.path.split('.');
+    const paths = patch.path.split(PATH_SPLITTER);
     resource = navigate(resource, paths);
     const lastSubPath = paths[paths.length - 1];
 

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -210,6 +210,19 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.active).to.be.eq(expected);
             return done();
         });
+
+        it('REPLACE: with version number in path', done => {
+            const expected = 'newValue';
+            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
+            const patch: ScimPatchAddReplaceOperation = {
+                op: 'replace',
+                value: expected,
+                path: path
+            };
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch[path]).to.be.eq(expected);
+            return done();
+        });
     });
 
     describe('add', () => {
@@ -402,6 +415,18 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.newProperty).to.be.eq(expected);
             return done();
         });
+
+        it('ADD: with version number in path', done => {
+            const expected = 'newValue';
+            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
+            delete scimUser[path];
+            const patch: ScimPatchAddReplaceOperation = {
+                op: 'add', value: 'newValue', path: path
+            };
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch[path]).to.be.eq(expected);
+            return done();
+        });
     });
     describe('remove', () => {
         it('REMOVE: with no path', done => {
@@ -468,6 +493,14 @@ describe('SCIM PATCH', () => {
             const patch: ScimPatchRemoveOperation = {op: 'Remove', path: 'active'};
             const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
             expect(afterPatch.active).not.to.exist;
+            return done();
+        });
+
+        it('REMOVE: with version number in path', done => {
+            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
+            const patch: ScimPatchRemoveOperation = {op: 'remove', path: path};
+            const afterPatch: ScimUser = <ScimUser>scimPatch(scimUser, [patch]);
+            expect(afterPatch[path]).not.to.exist;
             return done();
         });
     });

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -39,4 +39,5 @@ export interface ScimUser extends ScimResource {
     meta: ScimMeta & { resourceType: 'User' };
     newProperty?: string;
     newProperty3?: string;
+    'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department'?: string;
 }


### PR DESCRIPTION
Azure AD can have keys who looks like `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department` with a `.` in it.

This PR changes the way to split the path to be compatible with this kind of keys.

**It resolves issue #19.**