### PR TITLE
Bump to v1 because this version is stable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scim-patch",
-  "version": "0.2.4",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scim-patch",
-  "version": "0.2.4",
+  "version": "1.0.0",
   "description": "SCIM Patch operation (rfc7644).",
   "main": "lib/src/scimPatch.js",
   "types": "lib/src/scimPatch.d.ts",


### PR DESCRIPTION
After running this code for a long time in production, I move to v1 to have a better naming.
No change in this version, this is purely for naming purpose.