### PR TITLE
Return noTarget if the valuePath target a non existing object

### DIFF
--- a/src/errors/scimErrors.ts
+++ b/src/errors/scimErrors.ts
@@ -31,3 +31,12 @@ export class InvalidScimPatchRequest extends InvalidScimPatch {
     super(`The SCIM patch request is invalid: ${message}`);
   }
 }
+
+export class NoTarget extends InvalidScimPatch {
+ constructor(valuePath: string) {
+   super(
+     `Target location is a multi-valued attribute for which a value selection filter (${valuePath}) has been supplied and no record match was made.`,
+     'noTarget'
+   );
+ }
+}

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -3,7 +3,8 @@ import {
     InvalidScimPatch,
     InvalidScimPatchOp,
     NoPathInScimPatchOp,
-    InvalidScimPatchRequest
+    InvalidScimPatchRequest,
+    NoTarget
 } from './errors/scimErrors';
 import {
     ScimPatchSchema,
@@ -159,6 +160,9 @@ function applyAddOrReplaceOperation(scimResource: ScimResource, patch: ScimPatch
     const lastSubPath = paths[paths.length - 1];
 
     if (!IS_ARRAY_SEARCH.test(lastSubPath)) {
+        if (resource === undefined) {
+            throw new NoTarget(patch.value)
+        }
         resource[lastSubPath] = addOrReplaceAttribute(resource[lastSubPath], patch);
         return scimResource;
     }

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -8,6 +8,7 @@ import {
 import {ScimUser} from './types/types.test';
 import {expect} from 'chai';
 import {ScimPatchAddReplaceOperation, ScimPatchRemoveOperation} from '../src/types/types';
+import {NoTarget} from "../src/errors/scimErrors";
 
 describe('SCIM PATCH', () => {
     let scimUser: ScimUser;
@@ -237,6 +238,19 @@ describe('SCIM PATCH', () => {
             expect(afterPatch[path]).to.be.eq(expected);
             return done();
         });
+
+        it("REPLACE: no record match was made", (done) => {
+            // empty the surName fields.
+            scimUser.surName = [];
+            const patch: ScimPatchAddReplaceOperation = {
+                op: "replace",
+                path: "surName[primary eq true].value",
+                value: "surname"
+            };
+            expect(() => scimPatch(scimUser, [patch])).to.throw(NoTarget);
+            return done();
+        });
+
     });
 
     describe('add', () => {


### PR DESCRIPTION
Following issue #42, this PR avoids the library to crash if we filter on a target that is undefined.

The RFC specify :
>   o  If the target location is a complex multi-valued attribute with a
      value selection filter ("valuePath") and a specific sub-attribute
      (e.g., "addresses[type eq "work"].streetAddress"), the matching
      sub-attribute of all matching records is replaced.

>   o  If the target location is a multi-valued attribute for which a
      value selection filter ("valuePath") has been supplied and no
      record match was made, the service provider SHALL indicate failure
      by returning HTTP status code 400 and a "scimType" error code of
      "noTarget".

You will now receive a `NoTarget` exception if you try to do a filter on a non-existing target.