### PR TITLE
Fix #74

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "scim-patch",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scim-patch",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "SCIM Patch operation (rfc7644).",
   "main": "lib/src/scimPatch.js",
   "types": "lib/src/scimPatch.d.ts",

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -188,12 +188,12 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
     // Get the list of items who are successful for the search query.
     const matchFilter = filterWithQuery<any>(array, valuePath);
 
-    // If the target location specifies a complex attribute, a set of sub-attributes SHALL be specified in the "value"
-    // parameter, which replaces any existing values or adds where an attribute did not previously exist.
+    // If the target location is a multi-valued attribute for which a value selection filter ("valuePath") has been
+    // supplied and no record match was made, the service provider SHALL indicate failure by returning HTTP status
+    // code 400 and a "scimType" error code of "noTarget".
     const isReplace = patch.op.toLowerCase() === 'replace';
     if (isReplace && matchFilter.length === 0) {
-        array.push(patch.value);
-        return scimResource;
+        throw new NoTarget(patch.value)
     }
 
     // We are sure to find an index because matchFilter comes from array.

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -129,15 +129,14 @@ describe('SCIM PATCH', () => {
         });
 
         it('REPLACE: nested object do not exists', done => {
-            scimUser.surName = [{value: 'toto', primary: true}];
-            const expected = 'toto@toto.com';
-            const patch1: ScimPatchAddReplaceOperation = {
+            // empty the surName fields.
+            scimUser.surName = [];
+            const patch: ScimPatchAddReplaceOperation = {
                 op: 'replace',
-                value: {value: expected, primary: false},
-                path: 'surName[primary eq false]'
+                path: 'surName[value eq "bogus"]',
+                value: 'this value should not be added',
             };
-            const afterPatch = scimPatch(scimUser, [patch1]);
-            expect(afterPatch.surName?.length).to.be.eq(2);
+            expect(() => scimPatch(scimUser, [patch])).to.throw(NoTarget);
             return done();
         });
 
@@ -185,18 +184,6 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
-        it('REPLACE: should not modify anything if element not found', done => {
-            scimUser.name.nestedArray = [{primary: true, value: 'value1'}];
-            const patch1: ScimPatchAddReplaceOperation = {
-                op: 'replace', value: {
-                    newProperty1: 'toto'
-                }, path: 'name.nestedArray[toto eq true]'
-            };
-            const afterPatch = scimPatch(scimUser, [patch1]);
-            expect(afterPatch.name.nestedArray).to.be.eq(scimUser.name.nestedArray);
-            return done();
-        });
-
         it('REPLACE: with capital first letter for operation', done => {
             const expected = false;
             const patch: ScimPatchAddReplaceOperation = {op: 'Replace', value: {active: expected}};
@@ -238,19 +225,6 @@ describe('SCIM PATCH', () => {
                 op: "replace",
                 path: "surName[primary eq true].value",
                 value: "surname"
-            };
-            expect(() => scimPatch(scimUser, [patch])).to.throw(NoTarget);
-            return done();
-        });
-
-        // Test for https://github.com/thomaspoignant/scim-patch/issues/74
-        it("REPLACE: replace empty multivalued attribute", (done) => {
-            // empty the surName fields.
-            scimUser.surName = [];
-            const patch: ScimPatchAddReplaceOperation = {
-                op: 'replace',
-                path: 'surName[value eq "bogus"]',
-                value: 'this value should not be added',
             };
             expect(() => scimPatch(scimUser, [patch])).to.throw(NoTarget);
             return done();

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -7,6 +7,7 @@ export interface ScimUser extends ScimResource {
     surName?: Array<{
         value: string;
         primary: boolean;
+        additional?: string;
     }>;
     name: {
         familyName: string;


### PR DESCRIPTION
# Description
Before this PR a bug was occurring

>If the target location is a multi-valued attribute for which a
value selection filter ("valuePath") has been supplied and no
record match was made, the service provider SHALL indicate failure
by returning HTTP status code 400 and a "scimType" error code of
"noTarget".

We were adding a new item into the array when we should return a `NoTarget` error.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #74

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
