### PR TITLE
Add operations with no path and object dot notation not supported

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -307,23 +307,31 @@ function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperatio
     }
 
     if (typeof property === 'object') {
-        if (typeof patch.value !== 'object') {
-            if (patch.op === 'add')
-                throw new InvalidScimPatchOp('Invalid patch query.');
-
-            return patch.value;
-        }
-
-        // We add all the patch values to the property object.
-        for (const [key, value] of Object.entries(patch.value)) {
-            assign(property, key.split('.'), value);
-        }
-
-        return property;
+        return addOrReplaceObjectAttribute(property, patch);
     }
 
     // If the target location specifies a single-valued attribute, the existing value is replaced.
     return patch.value;
+}
+
+/**
+ * addOrReplaceObjectAttribute will add an attribute if it is an object
+ * @param property The property we want to replace
+ * @param patch The patch operation
+ */
+function addOrReplaceObjectAttribute(property: any, patch: ScimPatchAddReplaceOperation): any {
+    if (typeof patch.value !== 'object') {
+        if (patch.op === 'add')
+            throw new InvalidScimPatchOp('Invalid patch query.');
+
+        return patch.value;
+    }
+
+    // We add all the patch values to the property object.
+    for (const [key, value] of Object.entries(patch.value)) {
+        assign(property, key.split('.'), value);
+    }
+    return property;
 }
 
 /**

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -314,14 +314,34 @@ function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperatio
             return patch.value;
         }
 
-        return {
-            ...property,
-            ...patch.value
-        };
+        // We add all the patch values to the property object.
+        for (const [key, value] of Object.entries(patch.value)) {
+            assign(property, key.split('.'), value);
+        }
+
+        return property;
     }
 
     // If the target location specifies a single-valued attribute, the existing value is replaced.
     return patch.value;
+}
+
+/**
+ * assign is taking an array of key and add the associated nested object.
+ * @param obj the object where we should the key
+ * @param keyPath an array which represent the path of the nested object
+ * @param value value to assign
+ */
+function assign(obj:any, keyPath:Array<string>, value:any) {
+    const lastKeyIndex = keyPath.length-1;
+    for (let i = 0; i < lastKeyIndex; ++ i) {
+        const key = keyPath[i];
+        if (!(key in obj)){
+            obj[key] = {};
+        }
+        obj = obj[key];
+    }
+    obj[keyPath[lastKeyIndex]] = value;
 }
 
 /**

--- a/test/patchValidation.test.ts
+++ b/test/patchValidation.test.ts
@@ -65,4 +65,19 @@ describe('PATCH Validation', () => {
         expect(() => patchBodyValidation(patch)).to.throw(InvalidScimPatchRequest);
         return done();
     });
+
+    it('Add with no path', done => {
+        const patch: any = {
+            schemas: ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            Operations: [{
+                op: 'add', value: {
+                    "name.givenName": "John",
+                    "name.familyName": "Doe",
+                    "name.formatted": "John Doe"
+                }
+            }]
+        };
+        expect(() => patchBodyValidation(patch)).to.not.throw();
+        return done();
+    });
 });

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -574,7 +574,8 @@ describe('SCIM PATCH', () => {
                 value: {
                     "name.givenName": "John",
                     "name.familyName": "Doe",
-                    "name.formatted": "John Doe"
+                    "name.formatted": "John Doe",
+                    "favorites.food": "lemon"
                 }
             };
             expect(scimUser.name.nestedArray).to.be.undefined;
@@ -583,6 +584,7 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.name.givenName).to.be.eq("John");
             expect(afterPatch.name.familyName).to.be.eq("Doe");
             expect(afterPatch.name.formatted).to.be.eq("John Doe");
+            expect(afterPatch?.favorites?.food).to.be.eq("lemon");
             return done();
         });
 

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -548,7 +548,7 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
-        // Check issue https://github.com/thomaspoignant/scim-patch/issues/42 to understand this usecase
+        // Check issue https://github.com/thomaspoignant/scim-patch/issues/42 to understand this use-case
         it("ADD: empty array add filter type + field 2nd level", (done) => {
             const patch: ScimPatchAddReplaceOperation = {
                 op: "Add",
@@ -566,6 +566,26 @@ describe('SCIM PATCH', () => {
             }
             return done();
         });
+
+        // Check issue https://github.com/thomaspoignant/scim-patch/issues/132 to understand this use-case
+        it("ADD: dot notation with no path", done => {
+            const patch: ScimPatchAddReplaceOperation = {
+                op: 'add',
+                value: {
+                    "name.givenName": "John",
+                    "name.familyName": "Doe",
+                    "name.formatted": "John Doe"
+                }
+            };
+            expect(scimUser.name.nestedArray).to.be.undefined;
+            const afterPatch = scimPatch(scimUser, [patch]);
+            console.log(afterPatch);
+            expect(afterPatch.name.givenName).to.be.eq("John");
+            expect(afterPatch.name.familyName).to.be.eq("Doe");
+            expect(afterPatch.name.formatted).to.be.eq("John Doe");
+            return done();
+        });
+
     });
     describe('remove', () => {
         it('REMOVE: with no path', done => {

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -45,5 +45,8 @@ export interface ScimUser extends ScimResource {
     meta: ScimMeta & { resourceType: 'User' };
     newProperty?: string;
     newProperty3?: string;
+    favorites?: {
+        food?: string
+    };
     'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department'?: string;
 }

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -24,6 +24,7 @@ export interface ScimUser extends ScimResource {
         surName2?: Array<string>;
         surName3?: string;
         notMandatory?: boolean;
+        formatted?: string;
     };
     active: boolean;
     emails: Array<{


### PR DESCRIPTION
# Description
This PR resolve issue #132.
There are more details in the issue, but before this PR the possibility to perform a `add` operation with a dotted notation without `path` was not possible in the PATCH.

**Azure** currently uses this way of doing PATCH requests.

## Associated RFC and response from MS:
> Took me a bit to find it in the spec – but it’s here: https://datatracker.ietf.org/doc/html/rfc7644#page-37
> The following example shows how to add one or more attributes to a User resource without using a "path" attribute.

```
PATCH /Users/2819c223-7f76-453a-919d-413861904646
   Host: example.com
   Accept: application/scim+json
   Content-Type: application/scim+json
   Authorization: Bearer h480djs93hd8
   If-Match: W/"a330bc54f0671c9"
 
   {
     "schemas":
       ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
     "Operations":[{
       "op":"add",
       "value":{
         "emails":[
           {
             "value":babs@jensen.org,
             "type":"home"
           }
         ],
         "nickname":"Babs"
     }]
   }
 
   In the above example, an additional value is added to the
   multi-valued attribute "emails".  The second attribute, "nickname",
   is added to the User resource.  If the resource already had an
   existing "nickname", the value is replaced per the processing rules
   above for single-valued attributes.
```

> The section I previously linked (page 37 or 7644) combined with https://datatracker.ietf.org/doc/html/rfc7644#section-3.10 together explain how we’re allowed to do this.

```
3.10.  Attribute Notation
 
   All operations share a common scheme for referencing simple and
   complex attributes.  In general, attributes are uniquely identified
   by prefixing the attribute name with its schema URN separated by a
   colon (":") character; e.g., the core User resource attribute
   'userName' is identified as
   "urn:ietf:params:scim:schemas:core:2.0:User:userName".  Clients MAY
   omit core schema attribute URN prefixes but SHOULD fully qualify
   extended attributes with the associated schema extension URN to avoid
   naming conflicts.  For example, the attribute 'age' defined in
   "urn:ietf:params:scim:schemas:exampleCo:2.0:hr" is uniquely
   identified as "urn:ietf:params:scim:schemas:exampleCo:2.0:hr:age".
   Complex attributes' sub-attributes are referenced via nested dot
   ('.') notation, i.e., {urn}:{Attribute name}.{Sub-Attribute name}.
   For example, the fully qualified path for a User's givenName is
   "urn:ietf:params:scim:schemas:core:2.0:User:name.givenName".  All
   facets (URN, attribute, and sub-attribute name) of the fully encoded
   attribute name are case insensitive.
```



# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
Resolve #132

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
