### PR TITLE
Handle schema URI prefixes in paths.  Fix enterprise user tests.

### DIFF
--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -53,6 +53,15 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
+        it('REPLACE: first level property with fully qualified path', done => {
+            const expected = false;
+            const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: expected, path: 'urn:ietf:params:scim:schemas:core:2.0:User:active'};
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch.active).to.be.eq(expected);
+            return done();
+        });
+
+
         it('REPLACE: first level property without path', done => {
             const expected = false;
             const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: {active: expected}};

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -37,7 +37,9 @@ describe('SCIM PATCH', () => {
         "lastModified": "2019-11-20T09:25:30.208Z",
         "location": "**REQUIRED**/Users/tea_4"
       },
-      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department": "value"
+      "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User" : {
+          "department": "value"
+      }
     }`);
         return done();
     });
@@ -192,16 +194,15 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
-        it('REPLACE: with version number in path', done => {
+        it('REPLACE: with extensions schema path', done => {
             const expected = 'newValue';
-            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
             const patch: ScimPatchAddReplaceOperation = {
                 op: 'replace',
                 value: expected,
-                path: path
+                path: 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department'
             };
             const afterPatch = scimPatch(scimUser, [patch]);
-            expect(afterPatch[path]).to.be.eq(expected);
+            expect(afterPatch['urn:ietf:params:scim:schemas:extension:enterprise:2.0:User']?.department).to.be.eq(expected);
             return done();
         });
 
@@ -462,15 +463,17 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
-        it('ADD: with version number in path', done => {
+        it('ADD: with extension schema path', done => {
             const expected = 'newValue';
-            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
-            delete scimUser[path];
+            const schemaExtension = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User';
+            delete scimUser[schemaExtension];
             const patch: ScimPatchAddReplaceOperation = {
-                op: 'add', value: 'newValue', path: path
+                op: 'add',
+                value: 'newValue',
+                path: 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department'
             };
             const afterPatch = scimPatch(scimUser, [patch]);
-            expect(afterPatch[path]).to.be.eq(expected);
+            expect(afterPatch[schemaExtension]?.department).to.be.eq(expected);
             return done();
         });
 
@@ -773,11 +776,13 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
-        it('REMOVE: with version number in path', done => {
-            const path = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department';
-            const patch: ScimPatchRemoveOperation = {op: 'remove', path: path};
+        it('REMOVE: with extensions schema path', done => {
+            const schemaExtension = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User';
+            const patch: ScimPatchRemoveOperation = {
+                op: 'remove',
+                path: 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department'};
             const afterPatch = scimPatch(scimUser, [patch]);
-            expect(afterPatch[path]).not.to.exist;
+            expect(afterPatch[schemaExtension]?.department).not.to.exist;
             return done();
         });
     });

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -48,5 +48,7 @@ export interface ScimUser extends ScimResource {
     favorites?: {
         food?: string
     };
-    'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User:department'?: string;
+    'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User'?: {
+        department: string;
+    }
 }


### PR DESCRIPTION
# Description
Patching custom schema extensions like the Enterprise User 2.0 schema did not work.  This PR updates the path parsing to correctly handle Core and non-Core schema URIs when supplied in a patch operation path.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #152 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
