### PR TITLE
Fix #161: Path Resolution with dot is patch query

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scim-patch",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scim-patch",
-      "version": "0.5.4",
+      "version": "0.5.5",
       "license": "Unlicense",
       "dependencies": {
         "eslint-plugin-testing-library": "^5.0.0-alpha.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "scim-patch",
       "version": "0.5.4",
       "license": "Unlicense",
       "dependencies": {
@@ -2530,9 +2531,9 @@
       }
     },
     "node_modules/json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "node_modules/json-schema-traverse": {
@@ -2567,18 +2568,18 @@
       }
     },
     "node_modules/jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/lcov-parse": {
@@ -6044,9 +6045,9 @@
       "dev": true
     },
     "json-schema": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
     "json-schema-traverse": {
@@ -6075,14 +6076,14 @@
       }
     },
     "jsprim": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
-        "json-schema": "0.2.3",
+        "json-schema": "0.4.0",
         "verror": "1.10.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scim-patch",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "SCIM Patch operation (rfc7644).",
   "main": "lib/src/scimPatch.js",
   "types": "lib/src/scimPatch.d.ts",

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -56,7 +56,7 @@ const IS_ARRAY_SEARCH = /(\[|\])/;
 // Regex to extract key and search request (ex: emails[primary eq true).
 const ARRAY_SEARCH = /^(.+)\[(.+)\]$/;
 // Split path on periods
-const SPLIT_PERIOD = /(?!\B"[^\[]*)\.(?![^\]]*"\B)/g;
+const SPLIT_PERIOD = /(?!\B"[^[]*)\.(?![^\]]*"\B)/g;
 // Valid patch operation, value needs to be in lowercase here.
 const AUTHORIZED_OPERATION = ['remove', 'add', 'replace'];
 

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -56,7 +56,7 @@ const IS_ARRAY_SEARCH = /(\[|\])/;
 // Regex to extract key and search request (ex: emails[primary eq true).
 const ARRAY_SEARCH = /^(.+)\[(.+)\]$/;
 // Split path on periods
-const SPLIT_PERIOD = /\./g;
+const SPLIT_PERIOD = /(?!\B"[^\[]*)\.(?![^\]]*"\B)/g;
 // Valid patch operation, value needs to be in lowercase here.
 const AUTHORIZED_OPERATION = ['remove', 'add', 'replace'];
 
@@ -133,10 +133,10 @@ function resolvePaths(path: string): string[] {
         // No schema prefix - this is a core schema path
         return path.split(SPLIT_PERIOD);
     }
-    
+
     const schemaUri = path.substring(0, uriIndex);
     const paths = path.substring(uriIndex +1).split(SPLIT_PERIOD);
-    switch(schemaUri) {        
+    switch(schemaUri) {
         case CORE_SCHEMA_GROUP:
         case CORE_SCHEMA_USER:
             // Ignore core schema URIs in paths.  These are allowed but not part of object keys
@@ -388,7 +388,7 @@ function filterWithQuery<T>(arr: Array<T>, querySearch: string): Array<T> {
     try {
         return arr.filter(filter(parse(querySearch)));
     } catch (error) {
-        throw new InvalidScimPatchOp("${error}");
+        throw new InvalidScimPatchOp(`${error}`);
     }
 }
 

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -279,6 +279,18 @@ describe('SCIM PATCH', () => {
             expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
             return done();
         });
+
+        it("REPLACE: filter with an email containing dots", (done) => {
+            const expected = [ {"value": "batman@superheroes.com","primary": true} ];
+            const patch: ScimPatchAddReplaceOperation = {
+                op: "Replace",
+                value: "batman@superheroes.com",
+                path: "emails[value eq \"spiderman@superheroes.com\"].value"
+            };
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch.emails).to.be.deep.eq(expected);
+            return done();
+        });
     });
 
     describe('add', () => {
@@ -592,7 +604,6 @@ describe('SCIM PATCH', () => {
             };
             expect(scimUser.name.nestedArray).to.be.undefined;
             const afterPatch = scimPatch(scimUser, [patch]);
-            console.log(afterPatch);
             expect(afterPatch.name.givenName).to.be.eq("John");
             expect(afterPatch.name.familyName).to.be.eq("Doe");
             expect(afterPatch.name.formatted).to.be.eq("John Doe");


### PR DESCRIPTION
# Description
Fix an issue when we had a `.` in the scim filter.
Example: `emails[value eq "spiderman.clark@superheroes.com"].value`

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)


# Closes issue(s)
Resolve #161 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
