### PR TITLE
fix #176 - allow adds when there is no matching target in an array

### DIFF
--- a/src/errors/scimErrors.ts
+++ b/src/errors/scimErrors.ts
@@ -50,6 +50,19 @@ export class FilterOnEmptyArray extends InvalidScimPatchOp {
   }
 }
 
+export class FilterArrayTargetNotFound extends InvalidScimPatchOp {
+  schema: any;
+  attrName: string;
+  valuePath: string;
+
+  constructor(message: string, attrName: string, valuePath: string, schema?: any) {
+    super(`${message}`);
+    this.attrName = attrName;
+    this.valuePath = valuePath;
+    this.schema = schema;
+  }
+}
+
 export class NoPathInScimPatchOp extends InvalidScimPatch {
   constructor() {
     super('Missing path in "remove" patch operation', 'noTarget');

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -226,9 +226,6 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
     }
 
     if (!IS_ARRAY_SEARCH.test(lastSubPath)) {
-        if (resource === undefined) {
-            throw new NoTarget(patch.path);
-        }
         resource[lastSubPath] = addOrReplaceAttribute(resource[lastSubPath], patch);
         return scimResource;
     }


### PR DESCRIPTION

# Description
Fix to allow PATCH operations to add values to multi-valued attributes when using a path filter.

# Changes include
- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [?] Breaking changes (change that is not backward-comptible and/or changes current functionality)

There are two tests that were changed to expect a NoTarget exception instead of InvalidScimPatchOp.  I'm not sure if you consider that throw behavior change breaking.

# Closes issue(s)
Resolve #176

# Checklist
- [X] I have tested this code
- [X] I have added unit test to cover this code
- [ ] I have updated the Readme
- [X] I have followed the [contributing guide](CONTRIBUTING.md)
