### PR TITLE
Allow ADD on multivalued path queries.

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -121,7 +121,7 @@ function validatePatchOperation(operation: ScimPatchOperation): void {
     if (operation.op === 'remove' && !operation.path)
         throw new NoPathInScimPatchOp();
 
-    if (operation.op === 'add' && !('value' in operation))
+    if (operation.op.toLowerCase() === 'add' && !('value' in operation))
         throw new InvalidScimPatchRequest(`The operation ${operation.op} MUST contain a "value" member whose content specifies the value to be added`);
 
     if (operation.path && typeof operation.path !== 'string')
@@ -350,7 +350,7 @@ function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperatio
  */
 function addOrReplaceObjectAttribute(property: any, patch: ScimPatchAddReplaceOperation): any {
     if (typeof patch.value !== 'object') {
-        if (patch.op === 'add')
+        if (patch.op.toLowerCase() === 'add')
             throw new InvalidScimPatchOp('Invalid patch query.');
 
         return patch.value;

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -216,7 +216,7 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
             ) {
                 const result: any = {};
                 result[parsedPath.attrPath] = parsedPath.compValue;
-                result[lastSubPath] = addOrReplaceAttribute(resource, patch);
+                result[lastSubPath] = addOrReplaceAttribute(resource, patch, true);
                 resource[e.attrName] = [...(resource[e.attrName] ?? []), result];
                 return scimResource;
             }
@@ -315,9 +315,10 @@ function navigate(inputSchema: any, paths: string[]): any {
  * Add or Replace a property in the ScimResource
  * @param property The property we want to replace
  * @param patch The patch operation
+ * @param multiValuedPathFilter True if thi is a multivalued path filter query
  * @return the patched property
  */
-function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperation): any {
+function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperation, multiValuedPathFilter?: boolean): any {
     if (Array.isArray(property)) {
         if (Array.isArray(patch.value)) {
             // if we're adding an array, we need to remove duplicated values from existing array
@@ -336,7 +337,7 @@ function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperatio
     }
 
     if (typeof property === 'object') {
-        return addOrReplaceObjectAttribute(property, patch);
+        return addOrReplaceObjectAttribute(property, patch, multiValuedPathFilter);
     }
 
     // If the target location specifies a single-valued attribute, the existing value is replaced.
@@ -347,10 +348,11 @@ function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperatio
  * addOrReplaceObjectAttribute will add an attribute if it is an object
  * @param property The property we want to replace
  * @param patch The patch operation
+ * @param multiValuedPathFilter True if thi is a multivalued path filter query
  */
-function addOrReplaceObjectAttribute(property: any, patch: ScimPatchAddReplaceOperation): any {
+function addOrReplaceObjectAttribute(property: any, patch: ScimPatchAddReplaceOperation, multiValuedPathFilter?: boolean): any {
     if (typeof patch.value !== 'object') {
-        if (patch.op.toLowerCase() === 'add')
+        if (patch.op.toLowerCase() === 'add' && !multiValuedPathFilter)
             throw new InvalidScimPatchOp('Invalid patch query.');
 
         return patch.value;

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -576,6 +576,18 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
+        it("ADD: existing array add filter type + field (Azure AD) with lower case add", (done) => {
+            const patch: ScimPatchAddReplaceOperation = { op: "add",value: "1122 Street Rd", path: "addresses[type eq \"work\"].formatted" };
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch.addresses?.length).to.be.eq(1);
+            if (afterPatch.addresses !== undefined){
+                const newAddress = afterPatch.addresses[0];
+                expect(newAddress.type).to.be.eq("work");
+                expect(newAddress.formatted).to.be.eq("1122 Street Rd");
+            }
+            return done();
+        });
+
         it("ADD: empty array multiple filter should throw an error", (done) => {
             const patch: ScimPatchAddReplaceOperation = {
                 op: "Add",


### PR DESCRIPTION
# Description
This PR solves a bug when you were using `add` and not `Add`.
We had inconsistent behavior depending on how you write the SCIM operation.

This PR now act the same way for `add` and `Add`.
This PR also solve the problem with multivalued path queries on a non existing object, it was raising an exception because of this part of the RFC:
```
If the target location specifies a complex attribute, a set of sub-attributes SHALL be specified in the "value" parameter.
```
but we are in a different use case so we need to accept the issue #187.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #187

Following the issues #42 and #176.

# Checklist
- [x] I have tested this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
