### PR TITLE
fix #207 - allow add/replace with custom schema attribute and no path

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -360,7 +360,7 @@ function addOrReplaceObjectAttribute(property: any, patch: ScimPatchAddReplaceOp
 
     // We add all the patch values to the property object.
     for (const [key, value] of Object.entries(patch.value)) {
-        assign(property, key.split('.'), value);
+        assign(property, resolvePaths(key), value);
     }
     return property;
 }

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -3,7 +3,7 @@ import {
     InvalidScimPatchRequest,
     NoPathInScimPatchOp,
     scimPatch,
-    InvalidScimPatch
+    InvalidScimPatch,
 } from '../src/scimPatch';
 import {ScimUser} from './types/types.test';
 import {expect} from 'chai';
@@ -38,6 +38,7 @@ describe('SCIM PATCH', () => {
         "location": "**REQUIRED**/Users/tea_4"
       },
       "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User" : {
+          "organization": "value",
           "department": "value"
       }
     }`);
@@ -83,6 +84,23 @@ describe('SCIM PATCH', () => {
             const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: {familyName: expected}, path: 'name'};
             const afterPatch = scimPatch(scimUser, [patch]);
             expect(afterPatch.name.familyName).to.be.eq(expected);
+            return done();
+        });
+
+        it('REPLACE: 2 level extension schema property without path', done => {
+            const expectedOrganization = 'newOrganization';
+            const expectedDepartment = 'newDepartment';
+            const schemaExtension = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User';
+
+            const patch: ScimPatchAddReplaceOperation = {
+                op: 'replace', value: {
+                    [`${schemaExtension}:organization`]: expectedOrganization,
+                    [`${schemaExtension}:department`]: expectedDepartment
+                }
+            };
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch[schemaExtension]?.organization).to.be.eq(expectedOrganization);
+            expect(afterPatch[schemaExtension]?.department).to.be.eq(expectedDepartment);
             return done();
         });
 
@@ -323,6 +341,20 @@ describe('SCIM PATCH', () => {
             const patch: ScimPatchAddReplaceOperation = {op: 'add', value: {newProperty: expected}, path: 'name'};
             const afterPatch = scimPatch(scimUser, [patch]);
             expect(afterPatch.name.newProperty).to.be.eq(expected);
+            return done();
+        });
+
+        it('ADD: 2 level extension schema property without path', done => {
+            const expectedDivision = 'newDepartment';
+            const schemaExtension = 'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User';
+
+            const patch: ScimPatchAddReplaceOperation = {
+                op: 'add', value: {
+                    [`${schemaExtension}:division`]: expectedDivision
+                }
+            };
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch[schemaExtension]?.division).to.be.eq(expectedDivision);
             return done();
         });
 

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -49,6 +49,8 @@ export interface ScimUser extends ScimResource {
         food?: string
     };
     'urn:ietf:params:scim:schemas:extension:enterprise:2.0:User'?: {
-        department: string;
+        organization?: string;
+        division?: string;
+        department?: string;
     }
 }


### PR DESCRIPTION
# Description
The path parsing when supplying a patch operation with no path but using a custom schema attribute is not correct.

The fix was very minor. The only change needed was to use the `resolvePaths` method in `addOrReplaceObjectAttribute` when parsing the keys from the value object.

Two new tests were added that cover both add and replace operations.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #207 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
