### PR TITLE
fixes #211

### DIFF
--- a/src/errors/scimErrors.ts
+++ b/src/errors/scimErrors.ts
@@ -83,3 +83,9 @@ export class NoTarget extends InvalidScimPatch {
    );
  }
 }
+
+export class InvalidRemoveOpPath extends InvalidScimPatch {
+  constructor() {
+    super(`Path specified in 'remove' operation doesn't exist`);
+  }
+}

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -309,15 +309,9 @@ function navigate(inputSchema: any, paths: string[], isRemoveOp: boolean): any {
             }
         } else {
             // The element is not an array.
-            switch (true) {
-                // If its a remove operation & the path doesn't exist,
-                // then there's no need to navigate further, can exit early
-                case !schema[subPath] && isRemoveOp:
-                    return false;
-                case !schema[subPath] && !isRemoveOp:
-                    schema[subPath] = {};
-            }
-            schema = schema[subPath];
+            if (!schema[subPath] && isRemoveOp)
+                return false;
+            schema = schema[subPath] || (schema[subPath] = {});
         }
     }
     return schema;

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -288,7 +288,7 @@ function extractArray(subPath: string, schema: any): ScimSearchQuery {
  * @param isRemoveOp a flag that tells whether the operation that invoked is remove or not
  * @return the parent object of the element we want to edit
  */
-function navigate(inputSchema: any, paths: string[], isRemoveOp: boolean): any {
+function navigate(inputSchema: any, paths: string[], isRemoveOp: boolean): Record<string, unknown> {
     let schema = inputSchema;
     for (let i = 0; i < paths.length - 1; i++) {
         const subPath = paths[i];

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -36,3 +36,9 @@ export interface ScimMeta {
   readonly lastModified: Date;
   readonly location?: string;
 }
+
+// NavigateOptions used to pass configuration to `navigate`
+export interface NavigateOptions {
+  // true for 'remove' operations, false otherwise
+  isRemoveOp?: boolean;
+}

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -896,7 +896,7 @@ describe('SCIM PATCH', () => {
             console.log(JSON.stringify(afterPatch));
             expect(afterPatch.someField).not.to.exist;
             return done();
-        })
+        });
     });
     describe('invalid requests', () => {
         it('INVALID: wrong operation name', done => {

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -889,6 +889,14 @@ describe('SCIM PATCH', () => {
             expect(afterPatch[schemaExtension]?.department).not.to.exist;
             return done();
         });
+
+        it('REMOVE: with unavailable nested fields', done => {
+            const patch: ScimPatchRemoveOperation = {op: 'remove', path: 'someField.level_1_depth.level_2_depth.final_depth'};
+            const afterPatch: any = scimPatch(scimUser, [patch]);
+            console.log(JSON.stringify(afterPatch));
+            expect(afterPatch.someField).not.to.exist;
+            return done();
+        })
     });
     describe('invalid requests', () => {
         it('INVALID: wrong operation name', done => {

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -893,7 +893,6 @@ describe('SCIM PATCH', () => {
         it('REMOVE: with unavailable nested fields', done => {
             const patch: ScimPatchRemoveOperation = {op: 'remove', path: 'someField.level_1_depth.level_2_depth.final_depth'};
             const afterPatch: any = scimPatch(scimUser, [patch]);
-            console.log(JSON.stringify(afterPatch));
             expect(afterPatch.someField).not.to.exist;
             return done();
         });


### PR DESCRIPTION
# Description

### What was the problem
Refer #211 

### How is it resolved?

Tweaked the signature of `navigate` function to add another paramter

```js
@param isRemoveOp a flag that tells whether the operation that invoked is remove or not
```

Using this additional piece of information, the `navigate` function can take a call to exit early from the function for remove operation if the path doesn't exist

```js
    if (!schema[subPath] && isRemoveOp)
        return false;
    schema = schema[subPath] || (schema[subPath] = {});
```

### How can we test the change?

Refer #211 description


# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
Resolve #211 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
