### PR TITLE
added `exclude` flag to `filterWithQuery`

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -234,7 +234,7 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
     const {valuePath, array} = extractArray(lastSubPath, resource);
 
     // Get the list of items who are successful for the search query.
-    const matchFilter = filterWithQuery<any>(array, valuePath, false);
+    const matchFilter = filterWithQuery<any>(array, valuePath);
 
     // If the target location is a multi-valued attribute for which a value selection filter ("valuePath") has been
     // supplied and no record match was made, the service provider SHALL indicate failure by returning HTTP status
@@ -288,7 +288,7 @@ function navigate(inputSchema: any, paths: string[]): any {
             try {
                 const {attrName, valuePath, array} = extractArray(subPath, schema);
                 // Get the item who is successful for the search query.
-                const matchFilter = filterWithQuery<any>(array, valuePath, false);
+                const matchFilter = filterWithQuery<any>(array, valuePath);
                 // We are sure to find an index because matchFilter comes from array.
                 const index = array.findIndex(item => matchFilter.includes(item));
                 if (index < 0) {
@@ -390,7 +390,7 @@ function assign(obj:any, keyPath:Array<string>, value:any) {
  * @param exclude a flag which if true, excludes the elements that match the filter
  * @return an array who contains the search results.
  */
-function filterWithQuery<T>(arr: Array<T>, querySearch: string, exclude: boolean): Array<T> {
+function filterWithQuery<T>(arr: Array<T>, querySearch: string, exclude?: boolean): Array<T> {
     try {
         const f = filter(parse(querySearch));
         return arr.filter(e => exclude ? !f(e) : f(e));

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -180,7 +180,7 @@ function applyRemoveOperation<T extends ScimResource>(scimResource: T, patch: Sc
     const {attrName, valuePath, array} = extractArray(lastSubPath, resource);
 
     // We keep only items who don't match the query if supplied.
-    resource[attrName] = array.filter((e: any) => !filterWithQuery<any>(array, valuePath).includes(e));
+    resource[attrName] = filterWithQuery<any>(array, valuePath, true);
 
     // If the complex multi-valued attribute has no remaining records, the attribute SHALL be considered unassigned.
     if (resource[attrName].length === 0)
@@ -234,7 +234,7 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
     const {valuePath, array} = extractArray(lastSubPath, resource);
 
     // Get the list of items who are successful for the search query.
-    const matchFilter = filterWithQuery<any>(array, valuePath);
+    const matchFilter = filterWithQuery<any>(array, valuePath, false);
 
     // If the target location is a multi-valued attribute for which a value selection filter ("valuePath") has been
     // supplied and no record match was made, the service provider SHALL indicate failure by returning HTTP status
@@ -288,7 +288,7 @@ function navigate(inputSchema: any, paths: string[]): any {
             try {
                 const {attrName, valuePath, array} = extractArray(subPath, schema);
                 // Get the item who is successful for the search query.
-                const matchFilter = filterWithQuery<any>(array, valuePath);
+                const matchFilter = filterWithQuery<any>(array, valuePath, false);
                 // We are sure to find an index because matchFilter comes from array.
                 const index = array.findIndex(item => matchFilter.includes(item));
                 if (index < 0) {
@@ -387,11 +387,13 @@ function assign(obj:any, keyPath:Array<string>, value:any) {
  * Return the items in the array who match the filter.
  * @param arr the collection where we are searching.
  * @param querySearch the search request.
+ * @param exclude a flag which if true, excludes the elements that match the filter
  * @return an array who contains the search results.
  */
-function filterWithQuery<T>(arr: Array<T>, querySearch: string): Array<T> {
+function filterWithQuery<T>(arr: Array<T>, querySearch: string, exclude: boolean): Array<T> {
     try {
-        return arr.filter(filter(parse(querySearch)));
+        const f = filter(parse(querySearch));
+        return arr.filter(e => exclude ? !f(e) : f(e));
     } catch (error) {
         throw new InvalidScimPatchOp(`${error}`);
     }


### PR DESCRIPTION
# Description

### What was the problem?

Consider the following line of code `scimPatch.ts:188`

```js
resource[attrName] = array.filter((e: any) => !filterWithQuery<any>(array, valuePath).includes(e));
```

The task is to exclude all the elements that match the filter expressed in `valuePath` variable.
To make the decision whether to keep an element or not, we are traversing through the array twice:
1. once by `filterWithQuery`
2. once by `.includes`

So, the total time complexity for all n elements would be 2n * n = O(n^2)

### How it is resolved?

The `filterWithQuery` function signature is modified by adding additional parameter `exclude` which decides whether elements that match the filter are excluded or not.

# Changes include
- [x] Performance improvement

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
