### PR TITLE
fixed addition of duplicate objects to array

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -323,7 +323,7 @@ function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperatio
         if (Array.isArray(patch.value)) {
             // if we're adding an array, we need to remove duplicated values from existing array
             if (patch.op.toLowerCase() === "add") {
-                const valuesToAdd = patch.value.filter(item => !property.includes(item));
+                const valuesToAdd = patch.value.filter(item => !deepIncludes(property, item));
                 return property.concat(valuesToAdd);
             }
             // else this is a replace operation
@@ -331,7 +331,7 @@ function addOrReplaceAttribute(property: any, patch: ScimPatchAddReplaceOperatio
         }
 
         const a = property;
-        if (!a.includes(patch.value))
+        if (!deepIncludes(a, patch.value))
             a.push(patch.value);
         return a;
     }
@@ -421,6 +421,17 @@ function removeWithPatchValue<T>(arr: Array<T>, itemsToRemove: Array<T> | Record
     });
 
     return arr;
+}
+
+/**
+ * deepIncludes has similar behaviour as Array.prototype.includes,
+ * just that instead of === for equality check, it uses deepEqual library
+ * @param array the array on which inclusion check has to be performed
+ * @param item the item whose inclusion has to be checked
+ * @returns true if the item is present, else false
+ */
+function deepIncludes(array: any[], item: any): boolean {
+    return array.some(el => deepEqual(item, el));
 }
 
 function isValidOperation(operation: string): boolean {

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -695,6 +695,42 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.newProperty).to.be.eq("1");
             return done();
         });
+
+        it("ADD: on adding duplicate objects to an array, value is object", done => {
+            const patch: ScimPatchAddReplaceOperation = {
+                op: "add",
+                path: "emails",
+                value: {
+                    value: "spiderman@superheroes.com",
+                    primary: true
+                }
+            };
+
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch.emails.length).to.be.eq(1);
+            return done();
+        });
+
+        it("ADD: on adding duplicate objects to an array, value is array of objects ", done => {
+            const patch: ScimPatchAddReplaceOperation = {
+                op: "add",
+                path: "emails",
+                value: [
+                    {
+                        value: "spiderman@superheroes.com",
+                        primary: true
+                    },
+                    {
+                        value: "batman@superheroes.com",
+                        primary: false
+                    }
+            ]
+            };
+
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch.emails.length).to.be.eq(2);
+            return done();
+        });
     });
     describe('remove', () => {
         it('REMOVE: with no path', done => {


### PR DESCRIPTION
# Description
### What was the problem?

Consider the following code snippet

```js
const scimResource = {
    displayName: 'Pandavas',
    members: [
        { name: 'Yudhisthira' },
        { name: 'Bhima' },
        { name: 'Arjuna' },
        { name: 'Nakula' },
        { name: 'Sahadeva' },
    ]
};

const patchOp = {
    op: 'add',
    path: 'members',
    value: { name: 'Arjuna' },
};

console.log(scimPatch(scimResource, [patchOp]));
```

It gives the following output

```js
{
    displayName: 'Pandavas',
    members: [
        { name: 'Yudhisthira' },
        { name: 'Bhima' },
        { name: 'Arjuna' },
        { name: 'Nakula' },
        { name: 'Sahadeva' },
        { name: 'Arjuna' },
    ]
}
```

Expected output: Document remains unchanged


### How it is resolved?

The old code was also ensuring that the element going to be added doesn't exist, but it was using the `Array.prototype.includes()` function, which works fine for primitive datatypes like `Number` & `string`, but not for `Object`. So I introduced a function `deepIncludes` which checks for existence using `deepEqual`

### How can we test the change?

Refer code snippet in the description section or changed to the `scimPatch.test.js`

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)