### PR TITLE
Make scimPatch() immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ const scimUser: ScimUser = {
 
 const patch: ScimPatchOperation = { op: 'replace', value: { active: false } };
 const patchedUser = scimPatch(scimUser, patch);
+// scimUser === patchedUser, see Options section if you want to avoid updating the original object
 ```
 
 This particular operation will return : 
@@ -92,5 +93,17 @@ This particular operation will return :
   "meta": { "resourceType": "User", "created": "2019-12-19T14:36:08.838Z", "lastModified": "2019-12-19T14:36:08.838Z" }
 }
 ```
+
+#### Options
+By default `scimPatch()` is updating the scim resource you pass in the function.  
+If you want to avoid this, you can add an option while calling `scimPatch()`, it will do a copy of the object and work
+on this copy.
+
+Your call will look like this now:
+```typescript
+const patchedUser = scimPatch(scimUser, patch, {mutateDocument: false});
+// scimUser !== patchedUser
+```
+
 # How can I contribute?
 See the [contributor's guide](CONTRIBUTING.md) for some helpful tips.

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -94,7 +94,7 @@ export function patchBodyValidation(body: ScimPatch): void {
 export function scimPatch<T extends ScimResource>(scimResource: T, patchOperations: Array<ScimPatchOperation>,
                                                   options: ScimPatchOptions = {mutateDocument: true}): T {
     if (!options.mutateDocument) {
-        scimResource = _deepClone(scimResource)
+        scimResource = _deepClone(scimResource);
     }
 
     return patchOperations.reduce((patchedResource, patch) => {

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -21,7 +21,7 @@ import {
     ScimPatch,
     ScimResource,
     ScimMeta,
-    FilterWithQueryOptions,
+    FilterWithQueryOptions, ScimPatchOptions,
 } from './types/types';
 import {parse, filter} from 'scim2-parse-filter';
 import deepEqual = require('fast-deep-equal');
@@ -91,7 +91,12 @@ export function patchBodyValidation(body: ScimPatch): void {
  * @return the scimResource patched.
  * @throws {InvalidScimPatchOp} if the patch could not happen.
  */
-export function scimPatch<T extends ScimResource>(scimResource: T, patchOperations: Array<ScimPatchOperation>): T {
+export function scimPatch<T extends ScimResource>(scimResource: T, patchOperations: Array<ScimPatchOperation>,
+                                                  options: ScimPatchOptions = {mutateDocument: true}): T {
+    if (!options.mutateDocument) {
+        scimResource = _deepClone(scimResource)
+    }
+
     return patchOperations.reduce((patchedResource, patch) => {
         switch (patch.op) {
             case 'remove':
@@ -448,5 +453,22 @@ class ScimSearchQuery {
       readonly valuePath: string,
       readonly array: Array<any>
     ) {
+    }
+}
+
+/**
+ * Deeply clone the object.
+ * https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
+ * @param  {any} obj value to clone
+ * @return {any} cloned obj
+ */
+function _deepClone<T>(obj: T) {
+    switch (typeof obj) {
+        case "object":
+            return JSON.parse(JSON.stringify(obj)); //Faster than ES5 clone - http://jsperf.com/deep-cloning-of-objects/5
+        case "undefined":
+            return null; //this is how JSON.stringify behaves for array items
+        default:
+            return obj; //no need to clone primitives
     }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -37,6 +37,11 @@ export interface ScimMeta {
   readonly location?: string;
 }
 
+// ScimPatchOptions is a set of options to change the way to perform your ScimPatch
+export interface ScimPatchOptions {
+  mutateDocument?: boolean
+}
+
 // filterWithQueryOptions: options used while calling filterWithQuery
 export interface FilterWithQueryOptions {
   // if true, excludes the elements that match the filter

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -309,6 +309,16 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.emails).to.be.deep.eq(expected);
             return done();
         });
+
+        // see https://github.com/thomaspoignant/scim-patch/issues/215
+        it('REPLACE: don\'t mutate the original object', done => {
+            const expected = false;
+            const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: expected, path: 'active'};
+            const afterPatch = scimPatch(scimUser, [patch], {mutateDocument:false});
+            expect(scimUser).not.to.be.eq(afterPatch);
+            return done();
+        });
+
     });
 
     describe('add', () => {
@@ -693,6 +703,15 @@ describe('SCIM PATCH', () => {
 
             const afterPatch = scimPatch(user, [patch]);
             expect(afterPatch.newProperty).to.be.eq("1");
+            return done();
+        });
+
+        // see https://github.com/thomaspoignant/scim-patch/issues/215
+        it('ADD: don\'t mutate the original object', done => {
+            const expected = 'newValue';
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: {newProperty: expected}};
+            const afterPatch = scimPatch(scimUser, [patch], {mutateDocument: false});
+            expect(scimUser).not.to.be.eq(afterPatch);
             return done();
         });
 

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -944,6 +944,14 @@ describe('SCIM PATCH', () => {
             expect(afterPatch[schemaExtension]?.department).not.to.exist;
             return done();
         });
+
+        // see https://github.com/thomaspoignant/scim-patch/issues/215
+        it('REPLACE: don\'t mutate the original object', done => {
+            const patch: ScimPatchRemoveOperation = {op: 'remove', path: 'active'};
+            const afterPatch = scimPatch(scimUser, [patch], {mutateDocument:false});
+            expect(scimUser).not.to.eq(afterPatch);
+            return done();
+        });
     });
     describe('invalid requests', () => {
         it('INVALID: wrong operation name', done => {


### PR DESCRIPTION
# Description
Add an `options` field to have specific behaviors on `scimPatch()`.
This option allows configuring `ScimPatch()` to make it immutable.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #215

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
