### PR TITLE
Remove _deepclone because we copy only objects

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -96,7 +96,7 @@ export function scimPatch<T extends ScimResource>(scimResource: T, patchOperatio
     if (!options.mutateDocument) {
         // Deeply clone the object.
         // https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
-        scimResource = JSON.parse(JSON.stringify(scimResource))
+        scimResource = JSON.parse(JSON.stringify(scimResource));
     }
 
     return patchOperations.reduce((patchedResource, patch) => {

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -94,7 +94,9 @@ export function patchBodyValidation(body: ScimPatch): void {
 export function scimPatch<T extends ScimResource>(scimResource: T, patchOperations: Array<ScimPatchOperation>,
                                                   options: ScimPatchOptions = {mutateDocument: true}): T {
     if (!options.mutateDocument) {
-        scimResource = _deepClone(scimResource);
+        // Deeply clone the object.
+        // https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
+        scimResource = JSON.parse(JSON.stringify(scimResource))
     }
 
     return patchOperations.reduce((patchedResource, patch) => {
@@ -453,22 +455,5 @@ class ScimSearchQuery {
       readonly valuePath: string,
       readonly array: Array<any>
     ) {
-    }
-}
-
-/**
- * Deeply clone the object.
- * https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)
- * @param  {any} obj value to clone
- * @return {any} cloned obj
- */
-function _deepClone<T>(obj: T) {
-    switch (typeof obj) {
-        case "object":
-            return JSON.parse(JSON.stringify(obj)); //Faster than ES5 clone - http://jsperf.com/deep-cloning-of-objects/5
-        case "undefined":
-            return null; //this is how JSON.stringify behaves for array items
-        default:
-            return obj; //no need to clone primitives
     }
 }


### PR DESCRIPTION
# Description
Remove `_deepclone()` because we copy only objects.
This is better for the coverage.

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
