### PR TITLE
treatMissingAsAdd optional handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ This particular operation will return :
 ```
 
 #### Options
+
+##### Mutate Document
 By default `scimPatch()` is updating the scim resource you pass in the function.  
 If you want to avoid this, you can add an option while calling `scimPatch()`, it will do a copy of the object and work
 on this copy.
@@ -103,6 +105,22 @@ Your call will look like this now:
 ```typescript
 const patchedUser = scimPatch(scimUser, patch, {mutateDocument: false});
 // scimUser !== patchedUser
+```
+
+##### Treat Missing as Add
+
+By default `scimPatch()` will throw an error if a replace operation targets an attribute that does not exist. 
+If you prefer to treat these operations as additions, then set `treatMissingAsAdd: true`
+
+```typescript 
+// scimUser has no addresses
+ const patch = {
+    op: 'replace',
+    path: 'addresses[type eq "work"].country',
+    value: 'Australia',
+};
+const patchedUser = scimPatch(scimUser, patch, {treatMissingAsAdd: true});
+// patchedUser.addresses[0].country === "Australia"
 ```
 
 # How can I contribute?

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -48,6 +48,8 @@ export interface ScimPatchOptions {
   // if true, patches are applied to the original passed document
   // if false, a copy of the original document is obtained and patches are applied to it
   mutateDocument?: boolean
+  // if true, missing attributes to be replaced will be treated as an ADD.
+  treatMissingAsAdd?: boolean
 }
 
 // filterWithQueryOptions: options used while calling filterWithQuery

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -169,6 +169,20 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
+        it('REPLACE: nested object do not exists can be treated as ADD', done => {
+            // empty the surName fields.
+            scimUser.emails = [];
+            const patch: ScimPatchAddReplaceOperation = {
+                op: 'replace',
+                path: 'addresses[type eq "work"].country',
+                value: 'Denmark',
+            };
+            const afterPatch = scimPatch(scimUser, [patch], { treatMissingAsAdd: true });
+            expect(afterPatch.addresses?.[0].country).to.be.eq("Denmark");
+            expect(afterPatch.addresses?.[0].type).to.be.eq("work");
+            return done();
+        });
+
         it('REPLACE: primary email value', done => {
             const expected = 'toto@toto.com';
             const patch1: ScimPatchAddReplaceOperation = {

--- a/test/types/types.test.ts
+++ b/test/types/types.test.ts
@@ -37,6 +37,7 @@ export interface ScimUser extends ScimResource {
     addresses?: Array<{
        type: string;
        formatted: string;
+       country?: string;
     }>;
     roles?: Array<{
         value: string;


### PR DESCRIPTION
# Description

* Active Directory send SCIM messages with `type=replace` where the attribute does not exist
* [SCIM 3.5.2.3](https://www.rfc-editor.org/rfc/rfc7644#section-3.5.2.3) specifies that replace operations should be treated as `add` if the attribute does not exist.
* Without this behaviour, some messages from AD cause an error to be thrown
* This PR resolves this issue by introducing an optional flag to the `scimPatch` function.
* There is a test to cover this path
* The optional flag defaults to false, so this is not a breaking change


# Changes include
- [x] New feature (non-breaking change that adds functionality)

# Closes issue(s)

https://github.com/thomaspoignant/scim-patch/issues/381

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
