### PR TITLE
Change the default behavior for treatMissingAsAdd

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ const patchedUser = scimPatch(scimUser, patch, {mutateDocument: false});
 
 ##### Treat Missing as Add
 
-By default `scimPatch()` will throw an error if a replace operation targets an attribute that does not exist. 
-If you prefer to treat these operations as additions, then set `treatMissingAsAdd: true`
+By default `scimPatch()` will treat as Add a replace operation that targets an attribute that does not exist.
+If you prefer to throw an error instead, then set `treatMissingAsAdd: false`
 
 ```typescript 
 // scimUser has no addresses
@@ -119,7 +119,7 @@ If you prefer to treat these operations as additions, then set `treatMissingAsAd
     path: 'addresses[type eq "work"].country',
     value: 'Australia',
 };
-const patchedUser = scimPatch(scimUser, patch, {treatMissingAsAdd: true});
+const patchedUser = scimPatch(scimUser, patch, {treatMissingAsAdd: false});
 // patchedUser.addresses[0].country === "Australia"
 ```
 

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -99,7 +99,7 @@ export function patchBodyValidation(body: ScimPatch): void {
  * @throws {InvalidScimPatchOp} if the patch could not happen.
  */
 export function scimPatch<T extends ScimResource>(scimResource: T, patchOperations: Array<ScimPatchOperation>,
-                                                  options: ScimPatchOptions = {mutateDocument: true, treatMissingAsAdd: false}): T {
+                                                  options: ScimPatchOptions = {mutateDocument: true, treatMissingAsAdd: true}): T {
     if (!options.mutateDocument) {
         // Deeply clone the object.
         // https://jsperf.com/deep-copy-vs-json-stringify-json-parse/25 (recursiveDeepCopy)

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -260,6 +260,19 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
+        it("REPLACE: no record match was made, treatMissingAsAdd false", (done) => {
+            // empty the surName fields.
+            scimUser.surName = [];
+            const patch: ScimPatchAddReplaceOperation = {
+                op: "replace",
+                path: "surName[primary eq true].value",
+                value: "surname"
+            };
+            expect(() => scimPatch(scimUser, [patch],{treatMissingAsAdd: false}))
+                .to.throw(NoTarget, 'a value selection filter (surName[primary eq true].value) has been supplied and no record match was made');
+            return done();
+        });
+
         it("REPLACE: no record match was made", (done) => {
             // empty the surName fields.
             scimUser.surName = [];
@@ -268,7 +281,9 @@ describe('SCIM PATCH', () => {
                 path: "surName[primary eq true].value",
                 value: "surname"
             };
-            expect(() => scimPatch(scimUser, [patch])).to.throw(NoTarget, 'a value selection filter (surName[primary eq true].value) has been supplied and no record match was made');
+
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch.surName).to.be.deep.eq([{"primary": true,"value": "surname"}]);
             return done();
         });
 
@@ -308,7 +323,7 @@ describe('SCIM PATCH', () => {
                 value: "1111 Street Rd",
                 path: "addresses[type eq \"work\"].formatted"
             };
-            expect(() => scimPatch(scimUser, [patch])).to.throw(NoTarget, 'a value selection filter (addresses[type eq "work"].formatted) has been supplied and no record match was made');
+            expect(() => scimPatch(scimUser, [patch], {treatMissingAsAdd: false})).to.throw(NoTarget, 'a value selection filter (addresses[type eq "work"].formatted) has been supplied and no record match was made');
             return done();
         });
 


### PR DESCRIPTION
# Description
⚠️ Changing the default behavior to map the RFC.

Considering the comment of @yubing24 [here](https://github.com/thomaspoignant/scim-patch/issues/381#issuecomment-1650533449) we will switch the default behavior of `treatMissingAsAdd` from `false` to `true`.

# Changes include
- [x] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
