### PR TITLE
fix Replace op with value of empty object results in circular reference

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -396,6 +396,12 @@ function addOrReplaceObjectAttribute(property: any, patch: ScimPatchAddReplaceOp
         return patch.value;
     }
 
+    // fix https://github.com/thomaspoignant/scim-patch/issues/489
+    // when trying to insert an empty object, we should directly insert it without merging.
+    if (Object.keys(patch.value).length === 0) {
+        return {};
+    }
+
     // We add all the patch values to the property object.
     for (const [key, value] of Object.entries(patch.value)) {
         assign(property, resolvePaths(key), value, patch.op);

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -62,7 +62,6 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
-
         it('REPLACE: first level property without path', done => {
             const expected = false;
             const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: {active: expected}};
@@ -348,6 +347,23 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
+        // see https://github.com/thomaspoignant/scim-patch/issues/489
+        it('REPLACE: Replace op with value of empty object results in circular reference', done => {
+            const expected = [
+                {
+                    "value": "spiderman@superheroes.com",
+                    "primary": true
+                },
+                {
+                    "type": "work",
+                    value: {}
+                }
+            ];
+            const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: {}, path: 'emails[type eq "work"].value'};
+            const afterPatch = scimPatch(scimUser, [patch], { mutateDocument: false, treatMissingAsAdd: true });
+            expect(afterPatch.emails).to.be.deep.eq(expected);
+            return done();
+        });
     });
 
     describe('add', () => {


### PR DESCRIPTION
# Description
Fix #489 

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
Resolve #489 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
