### PR TITLE
Fixed #693

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -243,7 +243,7 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
             ) {
                 const result: any = {};
                 result[parsedPath.attrPath] = parsedPath.compValue;
-                result[lastSubPath] = addOrReplaceAttribute(resource, patch, true);
+                result[lastSubPath] = addOrReplaceAttribute(undefined, patch, true);
                 resource[e.attrName] = [...(resource[e.attrName] ?? []), result];
                 return scimResource;
             } else if (
@@ -418,12 +418,6 @@ function addOrReplaceObjectAttribute(property: any, patch: ScimPatchAddReplaceOp
             throw new InvalidScimPatchOp('Invalid patch query.');
 
         return patch.value;
-    }
-
-    // fix https://github.com/thomaspoignant/scim-patch/issues/489
-    // when trying to insert an empty object, we should directly insert it without merging.
-    if (Object.keys(patch.value).length === 0) {
-        return {};
     }
 
     // We add all the patch values to the property object.

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -432,6 +432,14 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.emails).to.be.deep.eq(expected);
             return done();
         });
+
+        // see https://github.com/thomaspoignant/scim-patch/issues/693
+        it('REPLACE: Replace op with value of empty object should merge if the target property is an object', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: {}, path: 'name'};
+            const afterPatch = scimPatch(scimUser, [patch], { mutateDocument: false, treatMissingAsAdd: true });
+            expect(afterPatch.name).to.be.deep.eq(scimUser.name);
+            return done();
+        });
     });
 
     describe('add', () => {
@@ -933,6 +941,15 @@ describe('SCIM PATCH', () => {
             expect(afterPatch.emails[1].newProperty).to.be.eq(expected);       
             expect(afterPatch.emails[2].newProperty).to.be.eq(expected);       
             expect(afterPatch.emails[3].newProperty).to.be.eq(expected);  
+            return done();
+        });
+
+        
+        // see https://github.com/thomaspoignant/scim-patch/issues/693
+        it('ADD: value of empty object should merge if the target property is an object', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: {}, path: 'name'};
+            const afterPatch = scimPatch(scimUser, [patch], { mutateDocument: false, treatMissingAsAdd: true });
+            expect(afterPatch.name).to.be.deep.eq(scimUser.name);
             return done();
         });
     });


### PR DESCRIPTION
# Description
The problem was how the #489 issue was solved, the fix applied on all cases even when it was wrong.
I solved the problem by passing the `property` argument as undefined (to `addOrReplaceAttribute()`) in the case where the target of the valuePath was not found.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)

Resolve #693 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
