### PR TITLE
Fix typo in isReplaceOperation comment: REPACE → REPLACE

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -529,7 +529,7 @@ function isAddOperation(operation: string): boolean {
 }
 
 /**
- * isReplaceOperation check if the operation is an REPACE
+ * isReplaceOperation check if the operation is an REPLACE
  * @param operation the name of the SCIM Patch operation
  * @return true if this is a replace operation
  */


### PR DESCRIPTION
# Description

1. Updated the documentation comment to correctly spell "REPLACE" instead of "REPACE" in scimPatch.ts
2. No testing needed

# Changes include
- [x] no breaking changes just a JsDoc comments typo modification

# Closes issue(s)
Resolve #852

# Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the Readme
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)
