### PR TITLE
fix: prevent prototype pollution in patch paths (GHSA-9m6g-wc8r-q59c)

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -154,8 +154,8 @@ function resolvePaths(path: string): string[] {
         paths = path.split(SPLIT_PERIOD);
     } else {
         const schemaUri = path.substring(0, uriIndex);
-        paths = path.substring(uriIndex +1).split(SPLIT_PERIOD);
-        switch(schemaUri) {
+        paths = path.substring(uriIndex + 1).split(SPLIT_PERIOD);
+        switch (schemaUri) {
             case CORE_SCHEMA_GROUP:
             case CORE_SCHEMA_USER:
                 // Ignore core schema URIs in paths.  These are allowed but not part of object keys

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -68,6 +68,8 @@ const AUTHORIZED_OPERATION = ['remove', 'add', 'replace'];
 
 const CORE_SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User';
 const CORE_SCHEMA_GROUP = 'urn:ietf:params:scim:schemas:core:2.0:Group';
+// Keys that would let a patch reach Object.prototype (prototype pollution, GHSA-9m6g-wc8r-q59c).
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 
 export const PATCH_OPERATION_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp';
 /*
@@ -146,22 +148,30 @@ function validatePatchOperation(operation: ScimPatchOperation): void {
 function resolvePaths(path: string): string[] {
     const uriIndex = path.lastIndexOf(':');
 
+    let paths: string[];
     if (uriIndex < 0) {
         // No schema prefix - this is a core schema path
-        return path.split(SPLIT_PERIOD);
+        paths = path.split(SPLIT_PERIOD);
+    } else {
+        const schemaUri = path.substring(0, uriIndex);
+        paths = path.substring(uriIndex +1).split(SPLIT_PERIOD);
+        switch(schemaUri) {
+            case CORE_SCHEMA_GROUP:
+            case CORE_SCHEMA_USER:
+                // Ignore core schema URIs in paths.  These are allowed but not part of object keys
+                break;
+            default:
+                // Assume any other provided schema URI is an extension
+                paths.unshift(schemaUri);
+                break;
+        }
     }
 
-    const schemaUri = path.substring(0, uriIndex);
-    const paths = path.substring(uriIndex +1).split(SPLIT_PERIOD);
-    switch(schemaUri) {
-        case CORE_SCHEMA_GROUP:
-        case CORE_SCHEMA_USER:
-            // Ignore core schema URIs in paths.  These are allowed but not part of object keys
-            break;
-        default:
-            // Assume any other provided schema URI is an extension
-            paths.unshift(schemaUri);
-            break;
+    // Reject keys that would walk into Object.prototype (prototype pollution, GHSA-9m6g-wc8r-q59c).
+    for (const segment of paths) {
+        if (DANGEROUS_KEYS.has(segment)) {
+            throw new InvalidScimPatchOp(`Forbidden key in patch path: ${segment}`);
+        }
     }
     return paths;
 }

--- a/test/prototypePollution.test.ts
+++ b/test/prototypePollution.test.ts
@@ -1,0 +1,110 @@
+import { scimPatch } from "../src/scimPatch";
+import { ScimUser } from "./types/types.test";
+import { InvalidScimPatchOp } from "../src/errors/scimErrors";
+import { expect } from "chai";
+
+describe("Prototype pollution via scim-patch", () => {
+  let scimUser: ScimUser;
+
+  beforeEach(() => {
+    scimUser = JSON.parse(`{
+          "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+          "id": "tea_4",
+          "userName": "spiderman",
+          "name": { "familyName": "Parker", "givenName": "Peter" },
+          "active": true,
+          "emails": [{ "value": "spiderman@superheroes.com", "primary": true }],
+          "roles": [],
+          "meta": { "resourceType": "User", "created": "x", "lastModified": "x", "location": "x" }
+        }`);
+  });
+
+  afterEach(() => {
+    // Safety net: ensure nothing leaked onto the prototype even if a test fails.
+    delete (Object.prototype as any).polluted;
+    delete (Object.prototype as any).isAdmin;
+  });
+
+  it("rejects a value-key containing __proto__ instead of polluting Object.prototype", () => {
+    expect(() =>
+      scimPatch(scimUser, [
+        {
+          op: "add",
+          path: "name",
+          value: { "__proto__.polluted": "yes" },
+        },
+      ])
+    ).to.throw(InvalidScimPatchOp);
+
+    expect((Object.prototype as any).polluted).to.equal(undefined);
+    expect(({} as any).polluted).to.equal(undefined);
+  });
+
+  it("rejects the __proto__.isAdmin escalation shape", () => {
+    expect(() =>
+      scimPatch(scimUser, [
+        {
+          op: "add",
+          path: "name",
+          value: { "__proto__.isAdmin": true },
+        },
+      ])
+    ).to.throw(InvalidScimPatchOp);
+
+    expect((Object.prototype as any).isAdmin).to.equal(undefined);
+    expect(({} as any).isAdmin).to.equal(undefined);
+  });
+
+  it("rejects a __proto__ segment supplied through the patch path", () => {
+    expect(() =>
+      scimPatch(scimUser, [
+        {
+          op: "add",
+          path: "__proto__.polluted",
+          value: "yes",
+        },
+      ])
+    ).to.throw(InvalidScimPatchOp);
+
+    expect((Object.prototype as any).polluted).to.equal(undefined);
+    expect(({} as any).polluted).to.equal(undefined);
+  });
+
+  it("rejects constructor / prototype keys as well", () => {
+    expect(() =>
+      scimPatch(scimUser, [
+        {
+          op: "add",
+          path: "name",
+          value: { "constructor.prototype.polluted": "yes" },
+        },
+      ])
+    ).to.throw(InvalidScimPatchOp);
+
+    expect(() =>
+      scimPatch(scimUser, [
+        {
+          op: "add",
+          path: "prototype.polluted",
+          value: "yes",
+        },
+      ])
+    ).to.throw(InvalidScimPatchOp);
+
+    expect((Object.prototype as any).polluted).to.equal(undefined);
+    expect(({} as any).polluted).to.equal(undefined);
+  });
+
+  it("still applies a legitimate nested patch", () => {
+    const patched = scimPatch(scimUser, [
+      {
+        op: "add",
+        path: "name",
+        value: { givenName: "Miles" },
+      },
+    ]);
+
+    expect(patched.name.givenName).to.equal("Miles");
+    expect(patched.name.familyName).to.equal("Parker");
+  });
+});


### PR DESCRIPTION
# Description

- **Problem:** A SCIM `PATCH` whose value-key or path contained `__proto__`, `constructor`, or `prototype` (e.g. `value: { "__proto__.polluted": "x" }` or `path: "__proto__.polluted"`) was walked unfiltered by `resolvePaths` → `assign`/`navigate`, writing onto `Object.prototype` process-wide (prototype pollution, CWE-1321, GHSA-9m6g-wc8r-q59c).
- **Resolution:** Reject those keys in `resolvePaths()` — the single chokepoint shared by all three sinks — throwing `InvalidScimPatchOp`. Neutralizes both the value-key and path vectors.
- **Testing:** `test/prototypePollution.test.ts` rewritten to assert the patch throws and `Object.prototype` stays clean (value-key, path, and `constructor`/`prototype` cases), plus a legitimate-patch regression case. Full suite: 111 passing.
- **Breaking changes:** None. Legitimate SCIM clients never send these keys.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [ ] I have followed the [contributing guide](CONTRIBUTING.md)