### PR TITLE
fix: prevent prototype pollution via inherited properties (GHSA-2mhw-wcx5-v3xj)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ coverage
 .nyc_output
 .DS_Store
 output.txt
+.gstack/
+.context/

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -368,10 +368,17 @@ function navigate(inputSchema: any, paths: string[], options: NavigateOptions = 
             });
         } else {
             schemas = schemas.flatMap((schema)=>{
-                if (!schema[subPath] && options.isRemoveOp)
+                // Only treat own properties as existing. Following inherited keys (e.g. toString)
+                // would resolve to shared built-ins and allow prototype pollution
+                // (GHSA-2mhw-wcx5-v3xj). For own keys we keep the original "||" semantics so a
+                // falsy intermediate (e.g. a null attribute) is still replaced with a container.
+                const existing = (schema != null && Object.prototype.hasOwnProperty.call(schema, subPath))
+                    ? schema[subPath]
+                    : undefined;
+                if (!existing && options.isRemoveOp)
                     throw new InvalidRemoveOpPath();
 
-                return schema[subPath] || (schema[subPath] = {});
+                return existing || (schema[subPath] = {});
             });
         }
     }
@@ -448,7 +455,10 @@ function assign(obj:any, keyPath:Array<string>, value:any, op: string) {
     const lastKeyIndex = keyPath.length-1;
     for (let i = 0; i < lastKeyIndex; ++ i) {
         const key = keyPath[i];
-        if (!(key in obj)){
+        // Use an own-property check ("in" walks the prototype chain) so an inherited key
+        // (e.g. toString) is treated as missing and a fresh own container is created,
+        // instead of descending into a shared built-in (GHSA-2mhw-wcx5-v3xj).
+        if (!Object.prototype.hasOwnProperty.call(obj, key)){
             obj[key] = {};
         }
         obj = obj[key];

--- a/test/prototypePollution.test.ts
+++ b/test/prototypePollution.test.ts
@@ -47,8 +47,8 @@ describe("Prototype pollution via scim-patch", () => {
       ])
     ).to.throw(InvalidScimPatchOp);
 
-    expect((Object.prototype as any).polluted).to.equal(undefined);
-    expect(({} as any).polluted).to.equal(undefined);
+    expect((Object.prototype as any).polluted).to.be.undefined;
+    expect(({} as any).polluted).to.be.undefined;
   });
 
   it("rejects the __proto__.isAdmin escalation shape", () => {
@@ -62,8 +62,8 @@ describe("Prototype pollution via scim-patch", () => {
       ])
     ).to.throw(InvalidScimPatchOp);
 
-    expect((Object.prototype as any).isAdmin).to.equal(undefined);
-    expect(({} as any).isAdmin).to.equal(undefined);
+    expect((Object.prototype as any).isAdmin).to.be.undefined;
+    expect(({} as any).isAdmin).to.be.undefined;
   });
 
   it("rejects a __proto__ segment supplied through the patch path", () => {
@@ -77,8 +77,8 @@ describe("Prototype pollution via scim-patch", () => {
       ])
     ).to.throw(InvalidScimPatchOp);
 
-    expect((Object.prototype as any).polluted).to.equal(undefined);
-    expect(({} as any).polluted).to.equal(undefined);
+    expect((Object.prototype as any).polluted).to.be.undefined;
+    expect(({} as any).polluted).to.be.undefined;
   });
 
   it("rejects constructor / prototype keys as well", () => {
@@ -102,8 +102,8 @@ describe("Prototype pollution via scim-patch", () => {
       ])
     ).to.throw(InvalidScimPatchOp);
 
-    expect((Object.prototype as any).polluted).to.equal(undefined);
-    expect(({} as any).polluted).to.equal(undefined);
+    expect((Object.prototype as any).polluted).to.be.undefined;
+    expect(({} as any).polluted).to.be.undefined;
   });
 
   it("does not pollute an inherited built-in method via a dotted path (GHSA-2mhw-wcx5-v3xj)", () => {
@@ -115,8 +115,8 @@ describe("Prototype pollution via scim-patch", () => {
       },
     ]);
 
-    expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
-    expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+    expect((Object.prototype.toString as any).scimPatchPolluted).to.be.undefined;
+    expect(({} as any).toString.scimPatchPolluted).to.be.undefined;
     // The write must land on the resource's own property, not be silently dropped.
     expect((scimUser as any).toString.scimPatchPolluted).to.equal("polluted");
   });
@@ -129,8 +129,8 @@ describe("Prototype pollution via scim-patch", () => {
       },
     ]);
 
-    expect((Object.prototype.toString as any).noPathPolluted).to.equal(undefined);
-    expect(({} as any).toString.noPathPolluted).to.equal(undefined);
+    expect((Object.prototype.toString as any).noPathPolluted).to.be.undefined;
+    expect(({} as any).toString.noPathPolluted).to.be.undefined;
     expect((scimUser as any).toString.noPathPolluted).to.equal("polluted");
   });
 
@@ -142,10 +142,10 @@ describe("Prototype pollution via scim-patch", () => {
       { op: "add", path: "hasOwnProperty.scimPatchPolluted", value: "polluted" },
     ]);
 
-    expect((Object.prototype.valueOf as any).scimPatchPolluted).to.equal(undefined);
-    expect((Object.prototype.hasOwnProperty as any).scimPatchPolluted).to.equal(undefined);
-    expect(({} as any).valueOf.scimPatchPolluted).to.equal(undefined);
-    expect(({} as any).hasOwnProperty.scimPatchPolluted).to.equal(undefined);
+    expect((Object.prototype.valueOf as any).scimPatchPolluted).to.be.undefined;
+    expect((Object.prototype.hasOwnProperty as any).scimPatchPolluted).to.be.undefined;
+    expect(({} as any).valueOf.scimPatchPolluted).to.be.undefined;
+    expect(({} as any).hasOwnProperty.scimPatchPolluted).to.be.undefined;
     expect((scimUser as any).valueOf.scimPatchPolluted).to.equal("polluted");
     expect((scimUser as any).hasOwnProperty.scimPatchPolluted).to.equal("polluted");
   });
@@ -155,8 +155,8 @@ describe("Prototype pollution via scim-patch", () => {
       { op: "replace", path: "toString.scimPatchPolluted", value: "polluted" },
     ]);
 
-    expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
-    expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+    expect((Object.prototype.toString as any).scimPatchPolluted).to.be.undefined;
+    expect(({} as any).toString.scimPatchPolluted).to.be.undefined;
     expect((scimUser as any).toString.scimPatchPolluted).to.equal("polluted");
   });
 
@@ -165,8 +165,8 @@ describe("Prototype pollution via scim-patch", () => {
       { op: "add", path: "toString.deep.scimPatchPolluted", value: "polluted" },
     ]);
 
-    expect((Object.prototype.toString as any).deep).to.equal(undefined);
-    expect(({} as any).toString.deep).to.equal(undefined);
+    expect((Object.prototype.toString as any).deep).to.be.undefined;
+    expect(({} as any).toString.deep).to.be.undefined;
     expect((scimUser as any).toString.deep.scimPatchPolluted).to.equal("polluted");
   });
 
@@ -179,8 +179,8 @@ describe("Prototype pollution via scim-patch", () => {
       },
     ]);
 
-    expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
-    expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+    expect((Object.prototype.toString as any).scimPatchPolluted).to.be.undefined;
+    expect(({} as any).toString.scimPatchPolluted).to.be.undefined;
     expect((scimUser.emails[0] as any).toString.scimPatchPolluted).to.equal("polluted");
   });
 

--- a/test/prototypePollution.test.ts
+++ b/test/prototypePollution.test.ts
@@ -117,6 +117,8 @@ describe("Prototype pollution via scim-patch", () => {
 
     expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
     expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+    // The write must land on the resource's own property, not be silently dropped.
+    expect((scimUser as any).toString.scimPatchPolluted).to.equal("polluted");
   });
 
   it("does not pollute an inherited built-in method via a no-path dotted value key (GHSA-2mhw-wcx5-v3xj)", () => {
@@ -129,6 +131,7 @@ describe("Prototype pollution via scim-patch", () => {
 
     expect((Object.prototype.toString as any).noPathPolluted).to.equal(undefined);
     expect(({} as any).toString.noPathPolluted).to.equal(undefined);
+    expect((scimUser as any).toString.noPathPolluted).to.equal("polluted");
   });
 
   it("does not pollute other inherited members (valueOf, hasOwnProperty)", () => {
@@ -143,6 +146,8 @@ describe("Prototype pollution via scim-patch", () => {
     expect((Object.prototype.hasOwnProperty as any).scimPatchPolluted).to.equal(undefined);
     expect(({} as any).valueOf.scimPatchPolluted).to.equal(undefined);
     expect(({} as any).hasOwnProperty.scimPatchPolluted).to.equal(undefined);
+    expect((scimUser as any).valueOf.scimPatchPolluted).to.equal("polluted");
+    expect((scimUser as any).hasOwnProperty.scimPatchPolluted).to.equal("polluted");
   });
 
   it("does not pollute via a replace op on an inherited method", () => {
@@ -152,6 +157,7 @@ describe("Prototype pollution via scim-patch", () => {
 
     expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
     expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+    expect((scimUser as any).toString.scimPatchPolluted).to.equal("polluted");
   });
 
   it("does not pollute via deep nesting through an inherited method", () => {
@@ -161,6 +167,7 @@ describe("Prototype pollution via scim-patch", () => {
 
     expect((Object.prototype.toString as any).deep).to.equal(undefined);
     expect(({} as any).toString.deep).to.equal(undefined);
+    expect((scimUser as any).toString.deep.scimPatchPolluted).to.equal("polluted");
   });
 
   it("does not pollute via an inherited method after an array-search segment", () => {
@@ -174,6 +181,7 @@ describe("Prototype pollution via scim-patch", () => {
 
     expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
     expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+    expect((scimUser.emails[0] as any).toString.scimPatchPolluted).to.equal("polluted");
   });
 
   it("still creates nested structure under a null intermediate attribute (issue #186 regression)", () => {

--- a/test/prototypePollution.test.ts
+++ b/test/prototypePollution.test.ts
@@ -23,6 +23,17 @@ describe("Prototype pollution via scim-patch", () => {
     // Safety net: ensure nothing leaked onto the prototype even if a test fails.
     delete (Object.prototype as any).polluted;
     delete (Object.prototype as any).isAdmin;
+    // GHSA-2mhw-wcx5-v3xj: clean up any pollution of inherited built-in methods so a
+    // failing test cannot leak global state into the rest of the run.
+    for (const method of [
+      Object.prototype.toString,
+      Object.prototype.valueOf,
+      Object.prototype.hasOwnProperty,
+    ]) {
+      delete (method as any).scimPatchPolluted;
+      delete (method as any).noPathPolluted;
+      delete (method as any).deep;
+    }
   });
 
   it("rejects a value-key containing __proto__ instead of polluting Object.prototype", () => {
@@ -93,6 +104,86 @@ describe("Prototype pollution via scim-patch", () => {
 
     expect((Object.prototype as any).polluted).to.equal(undefined);
     expect(({} as any).polluted).to.equal(undefined);
+  });
+
+  it("does not pollute an inherited built-in method via a dotted path (GHSA-2mhw-wcx5-v3xj)", () => {
+    scimPatch(scimUser, [
+      {
+        op: "add",
+        path: "toString.scimPatchPolluted",
+        value: "polluted",
+      },
+    ]);
+
+    expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
+    expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+  });
+
+  it("does not pollute an inherited built-in method via a no-path dotted value key (GHSA-2mhw-wcx5-v3xj)", () => {
+    scimPatch(scimUser, [
+      {
+        op: "add",
+        value: { "toString.noPathPolluted": "polluted" },
+      },
+    ]);
+
+    expect((Object.prototype.toString as any).noPathPolluted).to.equal(undefined);
+    expect(({} as any).toString.noPathPolluted).to.equal(undefined);
+  });
+
+  it("does not pollute other inherited members (valueOf, hasOwnProperty)", () => {
+    scimPatch(scimUser, [
+      { op: "add", path: "valueOf.scimPatchPolluted", value: "polluted" },
+    ]);
+    scimPatch(scimUser, [
+      { op: "add", path: "hasOwnProperty.scimPatchPolluted", value: "polluted" },
+    ]);
+
+    expect((Object.prototype.valueOf as any).scimPatchPolluted).to.equal(undefined);
+    expect((Object.prototype.hasOwnProperty as any).scimPatchPolluted).to.equal(undefined);
+    expect(({} as any).valueOf.scimPatchPolluted).to.equal(undefined);
+    expect(({} as any).hasOwnProperty.scimPatchPolluted).to.equal(undefined);
+  });
+
+  it("does not pollute via a replace op on an inherited method", () => {
+    scimPatch(scimUser, [
+      { op: "replace", path: "toString.scimPatchPolluted", value: "polluted" },
+    ]);
+
+    expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
+    expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+  });
+
+  it("does not pollute via deep nesting through an inherited method", () => {
+    scimPatch(scimUser, [
+      { op: "add", path: "toString.deep.scimPatchPolluted", value: "polluted" },
+    ]);
+
+    expect((Object.prototype.toString as any).deep).to.equal(undefined);
+    expect(({} as any).toString.deep).to.equal(undefined);
+  });
+
+  it("does not pollute via an inherited method after an array-search segment", () => {
+    scimPatch(scimUser, [
+      {
+        op: "add",
+        path: "emails[primary eq true].toString.scimPatchPolluted",
+        value: "polluted",
+      },
+    ]);
+
+    expect((Object.prototype.toString as any).scimPatchPolluted).to.equal(undefined);
+    expect(({} as any).toString.scimPatchPolluted).to.equal(undefined);
+  });
+
+  it("still creates nested structure under a null intermediate attribute (issue #186 regression)", () => {
+    (scimUser as any).name = null;
+
+    const patched = scimPatch(scimUser, [
+      { op: "add", path: "name.givenName", value: "Miles" },
+    ]);
+
+    expect(patched.name.givenName).to.equal("Miles");
   });
 
   it("still applies a legitimate nested patch", () => {


### PR DESCRIPTION
## Summary

Fixes **GHSA-2mhw-wcx5-v3xj** — an incomplete fix for the earlier prototype-pollution advisory GHSA-9m6g-wc8r-q59c (#1112).

That fix added a denylist (`__proto__`, `constructor`, `prototype`) in `resolvePaths()`. The denylist only blocks those three literal segments. The path-traversal code still **followed inherited properties**, so a patch path segment like `toString` resolved to the shared `Object.prototype.toString` built-in, and a child key was assigned onto it — a process-global mutation.

Two attacker-controlled vectors, both polluting `Object.prototype.toString`:

```js
// 1. via path
scimPatch(victim, [{ op: "add", path: "toString.scimPatchPolluted", value: "polluted" }]);
// 2. via no-path dotted value key
scimPatch(victim, [{ op: "add", value: { "toString.noPathPolluted": "polluted" } }]);
// => ({}).toString.scimPatchPolluted === "polluted"   (process-global)
```

## Fix

Two traversal sites in `src/scimPatch.ts` used prototype-chain-aware property access:

- `navigate()` — `schema[subPath]` returned an inherited value as the container to descend into.
- `assign()` — `if (!(key in obj))` treated inherited props as already-existing (`in` walks the prototype chain).

Both now treat **only own properties** as existing via `Object.prototype.hasOwnProperty.call`. An inherited key is handled as a missing attribute: a fresh own container is created on the resource (shadowing the built-in on that instance only), and the shared built-in is never touched.

`navigate()` deliberately keeps the original `||` semantics for own keys, so a falsy own intermediate (e.g. a `null` attribute, issue #186) is still replaced with a container rather than throwing. The existing denylist is retained as defense in depth.

## Tests

`test/prototypePollution.test.ts` gains cases mirroring the advisory PoC and asserting on the **global** built-in (not just the instance):

- dotted-path vector, no-path dotted-value-key vector
- other inherited members (`valueOf`, `hasOwnProperty`)
- `replace` op, deep nesting (`toString.deep.x`), array-search-prefixed path
- regression guard: nested patch through a `null` intermediate attribute (issue #186) still builds structure

Each pollution test fails against the unfixed tree, so they are genuine regression guards for both hunks.

## Verification

- `npm run build` — clean (tsc, es2017; uses `hasOwnProperty.call`, not the ES2022 `Object.hasOwn`)
- `npm test` — **118 passing**, 99.5% statement coverage
- `npm run lint` — no issues

## Reviews

Two independent adversarial reviews were run. The first found and I fixed a regression (the issue #186 null-intermediate case). The second reviewed the final diff, attempted ~15 bypass vectors and reverted each hunk in isolation to confirm the tests have teeth — verdict: ship, no Critical/Important issues.

## Follow-up (out of scope, not a regression)

A patch whose `value` is a *live JS reference* to a shared object (e.g. `value: Object.prototype.toString`) can be written through by a later op. This reproduces identically on the current default branch and is unreachable from the threat model (untrusted SCIM bodies are JSON, which cannot carry a reference to a built-in). Worth a separate hardening note; not addressed here.

Note: per this repo's convention (cf. #1112 → #1113), the version bump is left to a separate release PR.