### PR TITLE
fix: pin auto-assign action to v4.0.1 to fix PR assignment

### DIFF
--- a/.github/workflows/auto-assign-pull-request.yml
+++ b/.github/workflows/auto-assign-pull-request.yml
@@ -3,12 +3,15 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   auto-assign:
     runs-on: ubuntu-latest
     steps:
       - name: 'Auto-assign PR'
-        uses: pozil/auto-assign-issue@v1
+        uses: pozil/auto-assign-issue@af6beea6bdf1e8eb373f061c5bc168681fc6d011 # v4.0.1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           assignees: thomaspoignant

--- a/.github/workflows/auto-assigne-issue.yml
+++ b/.github/workflows/auto-assigne-issue.yml
@@ -4,12 +4,15 @@ on:
     issues:
         types: [opened]
 
+permissions:
+    issues: write
+
 jobs:
     auto-assign:
         runs-on: ubuntu-latest
         steps:
             - name: 'Auto-assign issue'
-              uses: pozil/auto-assign-issue@v1
+              uses: pozil/auto-assign-issue@af6beea6bdf1e8eb373f061c5bc168681fc6d011 # v4.0.1
               with:
                   assignees: thomaspoignant
                   numOfAssignee: 1


### PR DESCRIPTION
# Description

The PR-assignment workflow was failing on every pull request with `Error: Couldn't find issue info in current context`. The root cause is the floating `pozil/auto-assign-issue@v1` tag resolving to a stale, issue-only build of the action: it only reads `payload.issue` (absent on `pull_request_target` events) and rejects the `numOfAssignee` input.

This PR pins both auto-assign workflows to `v4.0.1` by commit SHA, which natively handles `pull_request`/`pull_request_target`, runs on `node24` (clearing the Node 20 deprecation warning), and still accepts `numOfAssignee`. It also adds least-privilege `permissions` blocks to each workflow. To test: open a new PR and confirm the "PR assignment" workflow assigns the PR and finishes green.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolve #

# Checklist
- [ ] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
