### PR TITLE
fix: unhandled TypeError from crafted SCIM PATCH paths (GHSA-33jh-378v-h6r8)

### DIFF
--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -172,7 +172,7 @@ function resolvePaths(path: string): string[] {
         // An array-search segment ("emails[primary eq true]") carries its attribute name in front of
         // the filter, so "__proto__[primary eq true]" must be rejected like "__proto__"
         // (GHSA-33jh-378v-h6r8). ARRAY_SEARCH is the regex extractArray() uses to pick that name.
-        const key = segment.match(ARRAY_SEARCH)?.[1] ?? segment;
+        const key = ARRAY_SEARCH.exec(segment)?.[1] ?? segment;
         if (DANGEROUS_KEYS.has(key)) {
             throw new InvalidScimPatchOp(`Forbidden key in patch path: ${key}`);
         }

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -249,7 +249,7 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
         if (e instanceof FilterOnEmptyArray || e instanceof FilterArrayTargetNotFound) {
             const resource: Record<string, any> = e.schema;
             // check issue https://github.com/thomaspoignant/scim-patch/issues/42 to see why we should add this
-            const parsedPath = parse(e.valuePath);
+            const parsedPath = parseValuePath(e.valuePath);
             if (isAddOperation(patch.op) &&
               "compValue" in parsedPath &&
               parsedPath.compValue !== undefined &&
@@ -492,6 +492,20 @@ function assign(obj:any, keyPath:Array<string>, value:any, op: string) {
         return;
     }
     obj[keyPath[lastKeyIndex]] = value;
+}
+
+/**
+ * Parse a value filter (ex: primary eq true) and surface a malformed filter as a ScimError,
+ * as filterWithQuery() already does.
+ * @param valuePath the value filter to parse.
+ * @return the parsed filter.
+ */
+function parseValuePath(valuePath: string): ReturnType<typeof parse> {
+    try {
+        return parse(valuePath);
+    } catch (error) {
+        throw new InvalidScimPatchOp(`${error}`);
+    }
 }
 
 /**

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -394,6 +394,17 @@ function navigate(inputSchema: any, paths: string[], options: NavigateOptions = 
                 return existing || (schema[subPath] = {});
             });
         }
+
+        // Every element scoped so far must be a complex attribute (a non-null object) to be
+        // navigated into or written to. A primitive (e.g. "userName.foo") or an array of
+        // primitives would otherwise throw a raw TypeError at the next level or at the write site.
+        for (const schema of schemas) {
+            if (schema === null || typeof schema !== 'object') {
+                if (options.isRemoveOp)
+                    throw new InvalidRemoveOpPath();
+                throw new InvalidScimPatchOp(`Attribute "${subPath}" is not a complex attribute, it can't contain sub-attributes.`);
+            }
+        }
     }
     return schemas;
 }

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -169,8 +169,12 @@ function resolvePaths(path: string): string[] {
 
     // Reject keys that would walk into Object.prototype (prototype pollution, GHSA-9m6g-wc8r-q59c).
     for (const segment of paths) {
-        if (DANGEROUS_KEYS.has(segment)) {
-            throw new InvalidScimPatchOp(`Forbidden key in patch path: ${segment}`);
+        // An array-search segment ("emails[primary eq true]") carries its attribute name in front of
+        // the filter, so "__proto__[primary eq true]" must be rejected like "__proto__"
+        // (GHSA-33jh-378v-h6r8). ARRAY_SEARCH is the regex extractArray() uses to pick that name.
+        const key = segment.match(ARRAY_SEARCH)?.[1] ?? segment;
+        if (DANGEROUS_KEYS.has(key)) {
+            throw new InvalidScimPatchOp(`Forbidden key in patch path: ${key}`);
         }
     }
     return paths;
@@ -251,10 +255,19 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
               parsedPath.compValue !== undefined &&
               parsedPath.op === "eq"
             ) {
+                // FilterOnEmptyArray is raised for any non-array attribute, not only a missing one.
+                // Only a missing (nullish) attribute may be created as a new multi-valued attribute;
+                // an existing single-valued attribute cannot be targeted by a value filter and must
+                // not be spread or overwritten (GHSA-33jh-378v-h6r8). Throw a fresh error rather
+                // than `e`, which carries the parent object in `e.schema`.
+                const existing = resource[e.attrName];
+                if (existing != null && !Array.isArray(existing)) {
+                    throw new InvalidScimPatchOp('Impossible to search on a mono valued attribute.');
+                }
                 const result: any = {};
                 result[parsedPath.attrPath] = parsedPath.compValue;
                 result[lastSubPath] = addOrReplaceAttribute(undefined, patch, true);
-                resource[e.attrName] = [...(resource[e.attrName] ?? []), result];
+                resource[e.attrName] = [...(existing ?? []), result];
                 return scimResource;
             } else if (
               treatMissingAsAdd &&

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -60,6 +60,7 @@ export {
 // Regex to check if this is search into array request.
 const IS_ARRAY_SEARCH = /(\[|\])/;
 // Regex to extract key and search request (ex: emails[primary eq true).
+// Must stay non-global: resolvePaths() calls exec() per path segment.
 const ARRAY_SEARCH = /^(.+)\[(.+)\]$/;
 // Split path on periods
 const SPLIT_PERIOD = /(?!\B"[^[]*)\.(?![^\]]*"\B)/g;
@@ -171,11 +172,8 @@ function resolvePaths(path: string): string[] {
     for (const segment of paths) {
         // An array-search segment ("emails[primary eq true]") carries its attribute name in front of
         // the filter, so "__proto__[primary eq true]" must be rejected like "__proto__"
-        // (GHSA-33jh-378v-h6r8). ARRAY_SEARCH is the regex extractArray() uses to pick that name.
-        const key = ARRAY_SEARCH.exec(segment)?.[1] ?? segment;
-        if (DANGEROUS_KEYS.has(key)) {
-            throw new InvalidScimPatchOp(`Forbidden key in patch path: ${key}`);
-        }
+        // (GHSA-33jh-378v-h6r8). ARRAY_SEARCH is non-global; exec() in this loop is safe.
+        rejectDangerousKey(ARRAY_SEARCH.exec(segment)?.[1] ?? segment);
     }
     return paths;
 }
@@ -264,6 +262,7 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
                 if (existing != null && !Array.isArray(existing)) {
                     throw new InvalidScimPatchOp('Impossible to search on a mono valued attribute.');
                 }
+                rejectDangerousKey(parsedPath.attrPath);
                 const result: any = {};
                 result[parsedPath.attrPath] = parsedPath.compValue;
                 result[lastSubPath] = addOrReplaceAttribute(undefined, patch, true);
@@ -335,6 +334,9 @@ function extractArray(subPath: string, schema: any): ScimSearchQuery {
         throw new InvalidScimPatchOp(`This part of the path ${subPath} is invalid for SCIM patch request.`);
 
     const [, attrName, valuePath] = matchRequest;
+    // Use-site denylist: resolvePaths already rejects these, but extractArray is what
+    // actually indexes the resource (GHSA-33jh-378v-h6r8). Keep both in sync.
+    rejectDangerousKey(attrName);
     const element = schema[attrName];
 
     if (!Array.isArray(element))
@@ -395,9 +397,11 @@ function navigate(inputSchema: any, paths: string[], options: NavigateOptions = 
             });
         }
 
-        // Every element scoped so far must be a complex attribute (a non-null object) to be
-        // navigated into or written to. A primitive (e.g. "userName.foo") or an array of
-        // primitives would otherwise throw a raw TypeError at the next level or at the write site.
+        // Every element scoped so far must be a complex attribute (a non-null object).
+        // Arrays pass `typeof === "object"`; a multi-valued attribute without a filter is
+        // flattened by the flatMap above into its elements, so an array of primitives
+        // becomes those primitives here and is rejected. Do not add Array.isArray() without
+        // covering unfiltered paths such as emails.<subAttr>, which rely on that flattening.
         for (const schema of schemas) {
             if (schema === null || typeof schema !== 'object') {
                 if (options.isRemoveOp)
@@ -503,6 +507,12 @@ function assign(obj:any, keyPath:Array<string>, value:any, op: string) {
         return;
     }
     obj[keyPath[lastKeyIndex]] = value;
+}
+
+function rejectDangerousKey(key: string): void {
+    if (DANGEROUS_KEYS.has(key)) {
+        throw new InvalidScimPatchOp(`Forbidden key in patch path: ${key}`);
+    }
 }
 
 /**

--- a/src/scimPatch.ts
+++ b/src/scimPatch.ts
@@ -71,6 +71,7 @@ const CORE_SCHEMA_USER = 'urn:ietf:params:scim:schemas:core:2.0:User';
 const CORE_SCHEMA_GROUP = 'urn:ietf:params:scim:schemas:core:2.0:Group';
 // Keys that would let a patch reach Object.prototype (prototype pollution, GHSA-9m6g-wc8r-q59c).
 const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+const MONO_VALUED_SEARCH_ERROR = 'Impossible to search on a mono valued attribute.';
 
 export const PATCH_OPERATION_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp';
 /*
@@ -192,7 +193,8 @@ function applyRemoveOperation<T extends ScimResource>(scimResource: T, patch: Sc
         if (error instanceof InvalidRemoveOpPath) {
             return scimResource;
         }
-        throw error;
+        // Do not surface FilterOnEmptyArray: it carries the parent resource in `.schema`.
+        throwWithoutAttachedSchema(error);
     }
 
     // Dealing with the last element of the path.
@@ -214,7 +216,14 @@ function applyRemoveOperation<T extends ScimResource>(scimResource: T, patch: Sc
     for (const resource of resources_scoped) {
 
         // The last element is an Array request.
-        const {attrName, valuePath, array} = extractArray(lastSubPath, resource);
+        let attrName: string;
+        let valuePath: string;
+        let array: Array<any>;
+        try {
+            ({attrName, valuePath, array} = extractArray(lastSubPath, resource));
+        } catch (error) {
+            throwWithoutAttachedSchema(error);
+        }
 
         // We keep only items who don't match the query if supplied.
         resource[attrName] = filterWithQuery<any>(array, valuePath, {excludeIfMatchFilter: true});
@@ -260,7 +269,7 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
                 // than `e`, which carries the parent object in `e.schema`.
                 const existing = resource[e.attrName];
                 if (existing != null && !Array.isArray(existing)) {
-                    throw new InvalidScimPatchOp('Impossible to search on a mono valued attribute.');
+                    throw new InvalidScimPatchOp(MONO_VALUED_SEARCH_ERROR);
                 }
                 rejectDangerousKey(parsedPath.attrPath);
                 const result: any = {};
@@ -299,7 +308,13 @@ function applyAddOrReplaceOperation<T extends ScimResource>(scimResource: T, pat
     // The last element is an Array request.
     for (const resource of resources_scoped) {
         
-        const {valuePath, array} = extractArray(lastSubPath, resource);
+        let valuePath: string;
+        let array: Array<any>;
+        try {
+            ({valuePath, array} = extractArray(lastSubPath, resource));
+        } catch (error) {
+            throwWithoutAttachedSchema(error);
+        }
 
         // Get the list of items who are successful for the search query.
         const matchFilter = filterWithQuery<any>(array, valuePath);
@@ -340,7 +355,7 @@ function extractArray(subPath: string, schema: any): ScimSearchQuery {
     const element = schema[attrName];
 
     if (!Array.isArray(element))
-        throw new FilterOnEmptyArray('Impossible to search on a mono valued attribute.', attrName, valuePath);
+        throw new FilterOnEmptyArray(MONO_VALUED_SEARCH_ERROR, attrName, valuePath);
 
     return new ScimSearchQuery(attrName, valuePath, element);
 }
@@ -513,6 +528,17 @@ function rejectDangerousKey(key: string): void {
     if (DANGEROUS_KEYS.has(key)) {
         throw new InvalidScimPatchOp(`Forbidden key in patch path: ${key}`);
     }
+}
+
+/**
+ * Re-throw FilterOnEmptyArray as a fresh InvalidScimPatchOp so callers do not
+ * receive the parent resource attached as `error.schema`.
+ */
+function throwWithoutAttachedSchema(error: unknown): never {
+    if (error instanceof FilterOnEmptyArray) {
+        throw new InvalidScimPatchOp(MONO_VALUED_SEARCH_ERROR);
+    }
+    throw error;
 }
 
 /**

--- a/test/prototypePollution.test.ts
+++ b/test/prototypePollution.test.ts
@@ -294,5 +294,45 @@ describe("Prototype pollution via scim-patch", () => {
       ).to.throw(InvalidScimPatchOp, "Impossible to search on a mono valued attribute");
       expect((scimUser as any).toString).to.equal(Object.prototype.toString);
     });
+
+    it("rejects a __proto__ array-search segment with no sub-attribute", () => {
+      expectForbiddenKey(scimUser, {
+        op: "add",
+        path: "__proto__[primary eq true]",
+        value: "yes",
+      });
+    });
+
+    it("rejects a __proto__ array-search segment on a null-prototype resource", () => {
+      const resource = Object.create(null);
+      expect(() =>
+        scimPatch(resource, [
+          { op: "add", path: "__proto__[primary eq true].polluted", value: "yes" },
+        ])
+      ).to.throw(InvalidScimPatchOp, "Forbidden key in patch path");
+      expect(Object.getPrototypeOf(resource)).to.equal(null);
+      expect((Object.prototype as any).polluted).to.be.undefined;
+    });
+
+    it("rejects __proto__ when it is the value-filter attribute on a missing array", () => {
+      const resource: any = {};
+      expectForbiddenKey(resource, {
+        op: "add",
+        path: "emails[__proto__ eq true].polluted",
+        value: "yes",
+      });
+      expect(resource.emails).to.be.undefined;
+    });
+
+    it("rejects constructor when it is the value-filter attribute on a missing array", () => {
+      const resource: any = {};
+      expectForbiddenKey(resource, {
+        op: "add",
+        path: "emails[constructor eq true].value",
+        value: "x",
+      });
+      expect(resource.emails).to.be.undefined;
+      expect((Function.prototype as any).polluted).to.be.undefined;
+    });
   });
 });

--- a/test/prototypePollution.test.ts
+++ b/test/prototypePollution.test.ts
@@ -1,6 +1,7 @@
 import { scimPatch } from "../src/scimPatch";
 import { ScimUser } from "./types/types.test";
 import { InvalidScimPatchOp } from "../src/errors/scimErrors";
+import { ScimPatchOperation } from "../src/types/types";
 import { expect } from "chai";
 
 describe("Prototype pollution via scim-patch", () => {
@@ -205,5 +206,93 @@ describe("Prototype pollution via scim-patch", () => {
 
     expect(patched.name.givenName).to.equal("Miles");
     expect(patched.name.familyName).to.equal("Parker");
+  });
+
+  describe("array-search path segments (GHSA-33jh-378v-h6r8)", () => {
+    // A segment such as "__proto__[primary eq true]" carries the dangerous key in front of the
+    // value filter. It must be rejected like a bare "__proto__" segment, and the resource must come
+    // out untouched: same prototype, not re-parented onto an Array, nothing on Object.prototype.
+    function expectForbiddenKey(resource: any, patch: ScimPatchOperation) {
+      expect(() => scimPatch(resource, [patch])).to.throw(
+        InvalidScimPatchOp,
+        "Forbidden key in patch path"
+      );
+      expect(Object.getPrototypeOf(resource)).to.equal(Object.prototype);
+      expect(resource instanceof Array).to.be.false;
+      expect((Object.prototype as any).polluted).to.be.undefined;
+      expect(({} as any).polluted).to.be.undefined;
+    }
+
+    it("rejects the advisory PoC on an empty resource", () => {
+      const resource: any = {};
+      expectForbiddenKey(resource, {
+        op: "add",
+        path: "__proto__[primary eq true].polluted",
+        value: "yes",
+      });
+    });
+
+    it("rejects a __proto__ array-search segment via add", () => {
+      expectForbiddenKey(scimUser, {
+        op: "add",
+        path: "__proto__[primary eq true].polluted",
+        value: "yes",
+      });
+    });
+
+    it("rejects a __proto__ array-search segment via replace", () => {
+      expectForbiddenKey(scimUser, {
+        op: "replace",
+        path: "__proto__[primary eq true].polluted",
+        value: "yes",
+      });
+    });
+
+    it("rejects a __proto__ array-search segment via remove", () => {
+      expectForbiddenKey(scimUser, {
+        op: "remove",
+        path: "__proto__[primary eq true].polluted",
+      });
+    });
+
+    it("rejects constructor and prototype array-search segments", () => {
+      expectForbiddenKey(scimUser, {
+        op: "add",
+        path: "constructor[primary eq true].polluted",
+        value: "yes",
+      });
+      expectForbiddenKey(scimUser, {
+        op: "add",
+        path: "prototype[primary eq true].polluted",
+        value: "yes",
+      });
+    });
+
+    it("rejects a __proto__ array-search segment behind a schema URN", () => {
+      expectForbiddenKey(scimUser, {
+        op: "add",
+        path: "urn:ietf:params:scim:schemas:core:2.0:User:__proto__[primary eq true].polluted",
+        value: "yes",
+      });
+    });
+
+    it("rejects a nested __proto__ array-search segment after a valid array filter", () => {
+      // The comparison value is deliberately unquoted: the period splitter does not split a
+      // segment that precedes a quoted literal, which would turn the path into a literal key.
+      expectForbiddenKey(scimUser, {
+        op: "add",
+        path: "emails[primary eq true].__proto__[primary eq true].polluted",
+        value: "yes",
+      });
+    });
+
+    it("rejects a value filter on an inherited built-in instead of crashing", () => {
+      expect(() =>
+        scimPatch(scimUser, [
+          { op: "add", path: "toString[primary eq true].newProperty", value: "yes" },
+        ])
+      ).to.throw(InvalidScimPatchOp, "Impossible to search on a mono valued attribute");
+      expect((scimUser as any).toString).to.equal(Object.prototype.toString);
+    });
   });
 });

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -715,6 +715,19 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
+        // The issue #42 fallback must keep working when the attribute exists but is null.
+        it("ADD: null array add filter type + field (issue #42)", (done) => {
+            (scimUser as any).addresses = null;
+            const patch: ScimPatchAddReplaceOperation = {
+                op: "add",
+                value: "1111 Street Rd",
+                path: "addresses[type eq \"work\"].formatted"
+            };
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch.addresses).to.deep.equal([{type: "work", formatted: "1111 Street Rd"}]);
+            return done();
+        });
+
         it("ADD: existing array add filter type + field (Azure AD)", (done) => {
             const patch: ScimPatchAddReplaceOperation = {
                 op: "Add",
@@ -1229,6 +1242,29 @@ describe('SCIM PATCH', () => {
                 path: 'emails[\' eq true].value'
             };
             expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            return done();
+        });
+
+        // GHSA-33jh-378v-h6r8: a value filter on an attribute that exists but is not an array must be
+        // rejected with a ScimError, without crashing or rewriting the attribute.
+        it('INVALID: add with a value filter on an existing complex mono valued attribute', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'name[primary eq true].newProperty'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute');
+            expect(scimUser.name).to.deep.equal({familyName: 'Parker', givenName: 'Peter'});
+            return done();
+        });
+
+        it('INVALID: add with a value filter on an existing string attribute', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'userName[primary eq true].newProperty'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute');
+            expect(scimUser.userName).to.equal('spiderman');
+            return done();
+        });
+
+        it('INVALID: replace with a value filter on an existing mono valued attribute is not treated as add', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: 'x', path: 'name[primary eq true].newProperty'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute');
+            expect(scimUser.name).to.deep.equal({familyName: 'Parker', givenName: 'Peter'});
             return done();
         });
     });

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -967,6 +967,14 @@ describe('SCIM PATCH', () => {
         });
     });
     describe('remove', () => {
+        // Navigating through a single-valued attribute has never removed anything; it must stay a no-op.
+        it('REMOVE: through a string attribute is a no-op', done => {
+            const patch: ScimPatchRemoveOperation = {op: 'remove', path: 'userName.foo'};
+            const afterPatch = scimPatch(scimUser, [patch]);
+            expect(afterPatch.userName).to.equal('spiderman');
+            return done();
+        });
+
         // A FilterOnEmptyArray raised while navigating a remove path must surface as a ScimError.
         it('REMOVE: with a value filter on a mono valued attribute in the path', done => {
             const patch: ScimPatchRemoveOperation = {op: 'remove', path: 'name[primary eq true].familyName'};
@@ -1288,6 +1296,45 @@ describe('SCIM PATCH', () => {
         it('INVALID: replace with a malformed value filter on a missing attribute', done => {
             const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: 'x', path: 'addresses[not a filter].formatted'};
             expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            return done();
+        });
+
+        // A path that navigates through a single-valued attribute (string, boolean, array of
+        // primitives) targets nothing that can hold a sub-attribute. It must be rejected with a
+        // ScimError instead of throwing a raw TypeError from the write site.
+        it('INVALID: add through a string attribute', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'userName.foo'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            expect(scimUser.userName).to.equal('spiderman');
+            return done();
+        });
+
+        it('INVALID: replace through a boolean attribute', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: 'x', path: 'active.foo'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            expect(scimUser.active).to.equal(true);
+            return done();
+        });
+
+        it('INVALID: add through a nested string attribute', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'name.givenName.foo'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            expect(scimUser.name).to.deep.equal({familyName: 'Parker', givenName: 'Peter'});
+            return done();
+        });
+
+        it('INVALID: add through an array of primitives', done => {
+            scimUser.name.surName2 = ['a', 'b'];
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'name.surName2.foo'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            expect(scimUser.name.surName2).to.deep.equal(['a', 'b']);
+            return done();
+        });
+
+        it('INVALID: add with a value filter after a string attribute', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'userName.emails[primary eq true].newProperty'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            expect(scimUser.userName).to.equal('spiderman');
             return done();
         });
     });

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -967,6 +967,14 @@ describe('SCIM PATCH', () => {
         });
     });
     describe('remove', () => {
+        // A FilterOnEmptyArray raised while navigating a remove path must surface as a ScimError.
+        it('REMOVE: with a value filter on a mono valued attribute in the path', done => {
+            const patch: ScimPatchRemoveOperation = {op: 'remove', path: 'name[primary eq true].familyName'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute');
+            expect(scimUser.name).to.deep.equal({familyName: 'Parker', givenName: 'Peter'});
+            return done();
+        });
+
         it('REMOVE: with no path', done => {
             const patch = <ScimPatchRemoveOperation>{op: 'remove'};
             expect(() => scimPatch(scimUser, [patch])).to.throw(NoPathInScimPatchOp);

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -8,7 +8,7 @@ import {
 import {ScimUser} from './types/types.test';
 import {expect} from 'chai';
 import {ScimPatchAddReplaceOperation, ScimPatchRemoveOperation} from '../src/types/types';
-import {RemoveValueNestedArrayNotSupported, NoTarget, RemoveValueNotArray} from "../src/errors/scimErrors";
+import {RemoveValueNestedArrayNotSupported, NoTarget, RemoveValueNotArray, FilterOnEmptyArray} from "../src/errors/scimErrors";
 
 describe('SCIM PATCH', () => {
     let scimUser: ScimUser;
@@ -975,10 +975,13 @@ describe('SCIM PATCH', () => {
             return done();
         });
 
-        // A FilterOnEmptyArray raised while navigating a remove path must surface as a ScimError.
+        // A FilterOnEmptyArray raised while navigating a remove path must surface as a ScimError
+        // without the parent resource attached as `error.schema`.
         it('REMOVE: with a value filter on a mono valued attribute in the path', done => {
             const patch: ScimPatchRemoveOperation = {op: 'remove', path: 'name[primary eq true].familyName'};
-            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute');
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute')
+                .and.not.be.instanceOf(FilterOnEmptyArray)
+                .and.not.have.property('schema');
             expect(scimUser.name).to.deep.equal({familyName: 'Parker', givenName: 'Peter'});
             return done();
         });
@@ -1274,6 +1277,24 @@ describe('SCIM PATCH', () => {
             const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'userName[primary eq true].newProperty'};
             expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute');
             expect(scimUser.userName).to.equal('spiderman');
+            return done();
+        });
+
+        it('INVALID: add with a value filter on a mono valued attribute as the last path segment', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'userName[primary eq true]'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute')
+                .and.not.be.instanceOf(FilterOnEmptyArray)
+                .and.not.have.property('schema');
+            expect(scimUser.userName).to.equal('spiderman');
+            return done();
+        });
+
+        it('INVALID: remove with a value filter on a mono valued attribute as the last path segment', done => {
+            const patch: ScimPatchRemoveOperation = {op: 'remove', path: 'name[primary eq true]'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp, 'Impossible to search on a mono valued attribute')
+                .and.not.be.instanceOf(FilterOnEmptyArray)
+                .and.not.have.property('schema');
+            expect(scimUser.name).to.deep.equal({familyName: 'Parker', givenName: 'Peter'});
             return done();
         });
 

--- a/test/scimPatch.test.ts
+++ b/test/scimPatch.test.ts
@@ -1275,5 +1275,20 @@ describe('SCIM PATCH', () => {
             expect(scimUser.name).to.deep.equal({familyName: 'Parker', givenName: 'Peter'});
             return done();
         });
+
+        // A malformed value filter on an attribute that does not exist yet must surface as a ScimError,
+        // not as a raw error from the filter parser.
+        it('INVALID: add with a malformed value filter on a missing attribute', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'add', value: 'x', path: 'addresses[not a filter].formatted'};
+            expect(scimUser.addresses).to.be.undefined;
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            return done();
+        });
+
+        it('INVALID: replace with a malformed value filter on a missing attribute', done => {
+            const patch: ScimPatchAddReplaceOperation = {op: 'replace', value: 'x', path: 'addresses[not a filter].formatted'};
+            expect(() => scimPatch(scimUser, [patch])).to.throw(InvalidScimPatchOp);
+            return done();
+        });
     });
 });


### PR DESCRIPTION
# Description

This PR fixes GHSA-33jh-378v-h6r8: a crafted SCIM PATCH path such as `__proto__[primary eq true].polluted` made `scimPatch()` throw a raw `TypeError` that escaped the library, so a caller catching only `ScimError` got an unhandled exception per request (no prototype pollution occurred).

The root cause is twofold: the `DANGEROUS_KEYS` check in `resolvePaths()` compared whole path segments, so the key in front of a value filter slipped through, and the issue #42 fallback in `applyAddOrReplaceOperation()` spread `resource[attrName]` without checking it is an array, which also crashed on any existing single-valued attribute and silently split a string attribute into characters.

This PR contains several changes:
- `resolvePaths()` now checks the attribute name of array-search segments against `DANGEROUS_KEYS`, using the same `ARRAY_SEARCH` regex as `extractArray()`.
- The missing-array fallback only creates a new multi-valued attribute when the attribute is nullish; an existing non-array attribute is rejected with `InvalidScimPatchOp`.
- A malformed value filter on a missing attribute is surfaced as `InvalidScimPatchOp` instead of a raw parser `Error` (new `parseValuePath()` helper).
- `navigate()` rejects paths that traverse a single-valued attribute (e.g. `userName.foo`), which threw `TypeError: Cannot create property` at the write site; `remove` through such a path stays a no-op.

Testing: 21 new tests reproduce every case and failed with the raw errors before the fix; `npm run mocha`, `npm run lint` and `npm test` are green with 100% line coverage on `src/scimPatch.ts`.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

# Closes issue(s)
Resolves https://github.com/thomaspoignant/scim-patch/security/advisories/GHSA-33jh-378v-h6r8

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
