### PR TITLE
bump to 0.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scim-patch",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "scim-patch",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "Unlicense",
       "dependencies": {
         "@types/node": "^26.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scim-patch",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "SCIM Patch operation (rfc7644).",
   "main": "lib/src/scimPatch.js",
   "types": "lib/src/scimPatch.d.ts",


### PR DESCRIPTION
# Description

`package.json` was still at `0.9.2` while the security fix a474c41 (GHSA-33jh-378…, unhandled `TypeError` from crafted SCIM PATCH paths) sits unreleased on `master`. Since `.github/workflows/release.yml` publishes whatever version `package.json` declares, this bumps it to `0.9.3` — a patch bump, matching semver for a bug/security fix and the repo's 0.9.x cadence.

This also syncs the two `"version"` fields in `package-lock.json`, which previous bump commits left stale at the old version; they were edited in place rather than regenerated, so no dependency entries churn.

To test: `npm run build && npm run lint && npm test` — all green locally (145 passing, 100% statements / 99.2% branches).

# Changes include
- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking changes (change that is not backward-comptible and/or changes current functionality)

_Release chore — no functional change in this PR; it only marks the release that ships the fix above._

# Closes issue(s)

N/A — version bump ahead of cutting the `0.9.3` GitHub release.

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)